### PR TITLE
RED-19 - Sync-Async Wrapper

### DIFF
--- a/mhs-reference-implementation/README.md
+++ b/mhs-reference-implementation/README.md
@@ -9,14 +9,27 @@ project's directory run:
 pipenv install
 ```
 
-### Run Tests
+### Running Tests
 `pipenv run tests` will run all tests.
 
-### Send a Message
-`pipenv run sender` will run the `main.py` script which will send an example GP Summary Upload message to Opentest.
+### Running an MHS Instance
+`pipenv run mhs` will run the `main.py` script (you can also run this directly). This will start up an MHS
+instance listening for 'client' requests on port 80 and asynchronous responses from Spine on port 443.
 
-A /certs directory is required with the following files (containing the certificates & keys provided when you registered
-for Opentest):
-- client.cert - Should include the following in this order: endpoint certificate, Endpoint issuing subCA certificate, Root CA Certificate, as provided by the Opentest team
-- client.key - Your endpoint private key, as provided by the Opentest team
-- client.pem - A copy of client.cert
+Any content POSTed to `/path` (for example) on port 80 will result in the request configuration for the `path` entry in
+`data/interactions.json` being loaded and the content sent as the body of the request to Spine. Adding entries to
+`interactions.json` will allow you to define new supported interactions.
+
+You will need to complete the setup steps below before being able to successfully connect to a Spine instance.
+
+#### Setup
+A `data/certs` directory should be created with the following files (containing the certificates & keys required to
+perform client authentication to the Spine instance you are using. For Openttest, these will have been provided when you
+were granted access):
+- `client.cert` - Should include the following in this order: endpoint certificate, endpoint issuing subCA certificate,
+root CA Certificate.
+- `client.key` - Your endpoint private key
+- `client.pem` - A copy of client.cert
+
+You will also need to configure your party key, by replacing the value of the `PARTY_ID` variable in `main.py` with your
+party key. If you are using Opentest, this will also have been provided when you were granted access.

--- a/mhs-reference-implementation/data/interactions/interactions.json
+++ b/mhs-reference-implementation/data/interactions/interactions.json
@@ -9,7 +9,7 @@
     "type": "text/xml",
     "charset": "UTF-8",
     "start": "<ebXMLHeader@spine.nhs.uk>",
-    "ebxml_wrapper_required": true,
+    "async_response_expected": true,
     "to_party_id": "YES-0000806",
     "cpa_id": "S20001A000182",
     "duplicate_elimination": true,
@@ -25,6 +25,6 @@
     "type": "text/xml",
     "charset": "UTF-8",
     "start": "<ebXMLHeader@spine.nhs.uk>",
-    "ebxml_wrapper_required": false
+    "async_response_expected": false
   }
 }

--- a/mhs-reference-implementation/main.py
+++ b/mhs-reference-implementation/main.py
@@ -34,13 +34,15 @@ message_parser = EbXmlRequestMessageParser()
 # Configure logging
 logging.basicConfig(format="%(asctime)s - %(levelname)s: %(message)s", level=logging.DEBUG)
 
-# Run the Tornado server
+# Run the Tornado servers
+callbacks = {}
+
 supplier_application = Application([(r"/.*", ClientRequestHandler, dict(sender=sender))])
 supplier_server = HTTPServer(supplier_application)
 supplier_server.listen(80)
 
 mhs_application = Application([
-    (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser))
+    (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=callbacks))
 ])
 mhs_server = HTTPServer(mhs_application,
                         ssl_options=dict(certfile=certs_file, keyfile=key_file, cert_reqs=ssl.CERT_REQUIRED,

--- a/mhs-reference-implementation/main.py
+++ b/mhs-reference-implementation/main.py
@@ -17,6 +17,8 @@ from mhs.sender.sender import Sender
 from mhs.transport.http_transport import HttpTransport
 
 ASYNC_TIMEOUT = 30
+# TODO: Replace this with your party ID.
+PARTY_ID = "PARTY-ID"
 
 data_dir = Path(ROOT_DIR) / "data"
 certs_dir = data_dir / "certs"
@@ -28,7 +30,7 @@ interactions_config_file = str(data_dir / "interactions" / "interactions.json")
 interactions_config = InteractionsConfigFile(interactions_config_file)
 message_builder = EbXmlRequestMessageBuilder()
 transport = HttpTransport(str(certs_dir))
-sender = Sender(interactions_config, message_builder, transport)
+sender = Sender(interactions_config, message_builder, transport, PARTY_ID)
 
 ack_builder = EbXmlAckMessageBuilder()
 message_parser = EbXmlRequestMessageParser()
@@ -45,7 +47,8 @@ supplier_server = HTTPServer(supplier_application)
 supplier_server.listen(80)
 
 mhs_application = Application([
-    (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=callbacks))])
+    (r".*", AsyncResponseHandler,
+     dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=callbacks, party_id=PARTY_ID))])
 mhs_server = HTTPServer(mhs_application,
                         ssl_options=dict(certfile=certs_file, keyfile=key_file, cert_reqs=ssl.CERT_REQUIRED,
                                          ca_certs=certs_file))

--- a/mhs-reference-implementation/main.py
+++ b/mhs-reference-implementation/main.py
@@ -16,6 +16,8 @@ from mhs.parser.ebxml_message_parser import EbXmlRequestMessageParser
 from mhs.sender.sender import Sender
 from mhs.transport.http_transport import HttpTransport
 
+ASYNC_TIMEOUT = 30
+
 data_dir = Path(ROOT_DIR) / "data"
 certs_dir = data_dir / "certs"
 certs_file = str(certs_dir / "client.pem")
@@ -37,13 +39,13 @@ logging.basicConfig(format="%(asctime)s - %(levelname)s: %(message)s", level=log
 # Run the Tornado servers
 callbacks = {}
 
-supplier_application = Application([(r"/.*", ClientRequestHandler, dict(sender=sender))])
+supplier_application = Application(
+    [(r"/.*", ClientRequestHandler, dict(sender=sender, callbacks=callbacks, async_timeout=ASYNC_TIMEOUT))])
 supplier_server = HTTPServer(supplier_application)
 supplier_server.listen(80)
 
 mhs_application = Application([
-    (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=callbacks))
-])
+    (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=callbacks))])
 mhs_server = HTTPServer(mhs_application,
                         ssl_options=dict(certfile=certs_file, keyfile=key_file, cert_reqs=ssl.CERT_REQUIRED,
                                          ca_certs=certs_file))

--- a/mhs-reference-implementation/mhs/builder/ebxml_message_builder.py
+++ b/mhs-reference-implementation/mhs/builder/ebxml_message_builder.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 from pathlib import Path
+from typing import Dict, Tuple
 
 from builder.pystache_message_builder import PystacheMessageBuilder
 from definitions import ROOT_DIR
@@ -28,11 +29,11 @@ class EbXmlMessageBuilder(PystacheMessageBuilder):
 
         super().__init__(ebxml_template_dir, template_file)
 
-    def build_message(self, message_dictionary):
+    def build_message(self, message_dictionary: Dict[str, str]) -> Tuple[str, str]:
         """Build an ebXML message by populating a Mustache template with values from the provided dictionary.
 
         :param message_dictionary: The dictionary of values to use when populating the template.
-        :return: A string containing a message suitable for sending to a remote MHS.
+        :return: A tuple string containing the ID generated for message created and the message value.
         """
         ebxml_message_dictionary = copy.deepcopy(message_dictionary)
 
@@ -42,4 +43,4 @@ class EbXmlMessageBuilder(PystacheMessageBuilder):
         ebxml_message_dictionary[TIMESTAMP] = timestamp
         logging.debug("Creating ebXML message with message ID '%s' and timestamp '%s'", message_id, timestamp)
 
-        return super().build_message(ebxml_message_dictionary)
+        return message_id, super().build_message(ebxml_message_dictionary)

--- a/mhs-reference-implementation/mhs/builder/tests/test_ebxml_ack_message_builder.py
+++ b/mhs-reference-implementation/mhs/builder/tests/test_ebxml_ack_message_builder.py
@@ -13,6 +13,8 @@ from utilities.xml_utilities import XmlUtilities
 EXPECTED_MESSAGES_DIR = "expected_messages"
 EXPECTED_EBXML = "ebxml_ack.xml"
 
+MOCK_UUID = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+
 
 class TestEbXmlAckMessageBuilder(TestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -24,11 +26,11 @@ class TestEbXmlAckMessageBuilder(TestCase):
     @patch.object(MessageUtilities, "get_timestamp")
     @patch.object(MessageUtilities, "get_uuid")
     def test_build_message(self, mock_get_uuid, mock_get_timestamp):
-        mock_get_uuid.return_value = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+        mock_get_uuid.return_value = MOCK_UUID
         mock_get_timestamp.return_value = "2012-03-15T06:51:08Z"
         expected_message = FileUtilities.get_file_string(str(self.expected_message_dir / EXPECTED_EBXML))
 
-        message = self.builder.build_message({
+        message_id, message = self.builder.build_message({
             FROM_PARTY_ID: "TESTGEN-201324",
             TO_PARTY_ID: "YEA-0000806",
             CPA_ID: "S1001A1630",
@@ -39,4 +41,6 @@ class TestEbXmlAckMessageBuilder(TestCase):
 
         expected_message_bytes = expected_message.encode()
         message_bytes = message.encode()
+
+        self.assertEqual(MOCK_UUID, message_id)
         XmlUtilities.assert_xml_equal(expected_message_bytes, message_bytes)

--- a/mhs-reference-implementation/mhs/builder/tests/test_ebxml_request_message_builder.py
+++ b/mhs-reference-implementation/mhs/builder/tests/test_ebxml_request_message_builder.py
@@ -12,6 +12,8 @@ from utilities.message_utilities import MessageUtilities
 EXPECTED_MESSAGES_DIR = "expected_messages"
 EXPECTED_EBXML = "ebxml_request.xml"
 
+MOCK_UUID = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+
 
 class TestEbXmlRequestMessageBuilder(TestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -23,11 +25,11 @@ class TestEbXmlRequestMessageBuilder(TestCase):
     @patch.object(MessageUtilities, "get_timestamp")
     @patch.object(MessageUtilities, "get_uuid")
     def test_build_message(self, mock_get_uuid, mock_get_timestamp):
-        mock_get_uuid.return_value = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+        mock_get_uuid.return_value = MOCK_UUID
         mock_get_timestamp.return_value = "2012-03-15T06:51:08Z"
         expected_message = FileUtilities.get_file_string(str(self.expected_message_dir / EXPECTED_EBXML))
 
-        message = self.builder.build_message({
+        message_id, message = self.builder.build_message({
             FROM_PARTY_ID: "TESTGEN-201324",
             TO_PARTY_ID: "YEA-0000806",
             CPA_ID: "S1001A1630",
@@ -46,4 +48,5 @@ class TestEbXmlRequestMessageBuilder(TestCase):
         normalized_expected_message = FileUtilities.normalize_line_endings(expected_message)
         normalized_message = FileUtilities.normalize_line_endings(message)
 
+        self.assertEqual(MOCK_UUID, message_id)
         self.assertEqual(normalized_expected_message, normalized_message)

--- a/mhs-reference-implementation/mhs/handler/async_response_handler.py
+++ b/mhs-reference-implementation/mhs/handler/async_response_handler.py
@@ -42,5 +42,5 @@ class AsyncResponseHandler(RequestHandler):
             ack_builder.RECEIVED_MESSAGE_ID: parsed_message[parser.MESSAGE_ID]
         }
 
-        ack_message = self.ack_builder.build_message(ack_context)
+        _, ack_message = self.ack_builder.build_message(ack_context)
         return ack_message

--- a/mhs-reference-implementation/mhs/handler/client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/client_request_handler.py
@@ -30,16 +30,16 @@ class ClientRequestHandler(RequestHandler):
 
         async_message_id = None
         try:
-            async_message_id, message = self.sender.prepare_message(interaction_name, self.request.body.decode())
+            interaction_is_async, async_message_id, message = self.sender.prepare_message(interaction_name,
+                                                                                          self.request.body.decode())
 
-            interaction_is_asynchronous = async_message_id is not None
-            if interaction_is_asynchronous:
+            if interaction_is_async:
                 self.callbacks[async_message_id] = self._write_async_response
                 logging.debug("Added callback for asynchronous message with ID '%s'", async_message_id)
 
             immediate_response = self.sender.send_message(interaction_name, message)
 
-            if interaction_is_asynchronous:
+            if interaction_is_async:
                 await self._pause_request(async_message_id)
             else:
                 # No async response expected. Just return the response to our initial request.

--- a/mhs-reference-implementation/mhs/handler/client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/client_request_handler.py
@@ -30,7 +30,7 @@ class ClientRequestHandler(RequestHandler):
 
         async_message_id = None
         try:
-            async_message_id, message = self.sender.build_message(interaction_name, self.request.body.decode())
+            async_message_id, message = self.sender.prepare_message(interaction_name, self.request.body.decode())
 
             interaction_is_asynchronous = async_message_id is not None
             if interaction_is_asynchronous:

--- a/mhs-reference-implementation/mhs/handler/client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/client_request_handler.py
@@ -1,31 +1,74 @@
 import logging
+from datetime import timedelta
+from typing import Callable, Dict
 
+from tornado.locks import Event
 from tornado.web import RequestHandler, HTTPError
 
-from mhs.sender.sender import UnknownInteractionError
+from mhs.sender.sender import UnknownInteractionError, Sender
 
 
 class ClientRequestHandler(RequestHandler):
     """A RequestHandler for client requests to this MHS."""
 
-    def initialize(self, sender):
+    def initialize(self, sender: Sender, callbacks: Dict[str, Callable[[str], None]], async_timeout: int):
         """Initialise this request handler with the provided configuration values.
 
         :param sender: The sender to use to send messages.
+        :param callbacks: The dictionary of callbacks to use when awaiting an asynchronous response.
+        :param async_timeout: The amount of time (in seconds) to wait for an asynchronous response.
         """
         self.sender = sender
+        self.callbacks = callbacks
+        self.async_response_received = Event()
+        self.async_timeout = async_timeout
 
-    def post(self):
+    async def post(self):
         logging.debug("Client POST received: %s", self.request)
 
         interaction_name = self.request.uri[1:]
 
         try:
-            message_id, response = self.sender.send_message(interaction_name, self.request.body.decode())
+            async_message_id, immediate_response = self.sender.send_message(interaction_name,
+                                                                            self.request.body.decode())
+            logging.debug("Message sent with ID '%s'. Received response: %s", async_message_id, immediate_response)
 
-            logging.debug("Message sent with ID '%s'. Received response: %s", message_id, response)
-
-            self.set_header("Content-Type", "text/xml")
-            self.write(response)
+            if async_message_id is not None:
+                # Async response expected.
+                await self._pause_request(async_message_id)
+            else:
+                # No async response expected. Just return the response to our initial request.
+                self._write_response(immediate_response)
         except UnknownInteractionError:
             raise HTTPError(404, "Unknown interaction ID: %s", interaction_name)
+
+    async def _pause_request(self, async_message_id):
+        """Pause the incoming request until an asynchronous response is received (or a timeout is hit).
+
+        :param async_message_id: The ID of the request that expects an asynchronous response.
+        :raises: An HTTPError if we timed out waiting for an asynchronous response.
+        """
+        self.callbacks[async_message_id] = self._write_async_response
+
+        try:
+            await self.async_response_received.wait(timedelta(seconds=self.async_timeout))
+        except TimeoutError:
+            raise HTTPError(log_message=f"Timed out waiting for a response to message {async_message_id}")
+
+        del self.callbacks[async_message_id]
+
+    def _write_response(self, message: str) -> None:
+        """Write the given message to the response.
+
+        :param message: The message to write to the response.
+        """
+        self.set_header("Content-Type", "text/xml")
+        self.write(message)
+
+    def _write_async_response(self, message: str) -> None:
+        """Write the given message to the response and notify anyone waiting that this has been done.
+
+        :param message: The message to write to the response.
+        """
+        self._write_response(message)
+        self.async_response_received.set()

--- a/mhs-reference-implementation/mhs/handler/client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/client_request_handler.py
@@ -21,9 +21,9 @@ class ClientRequestHandler(RequestHandler):
         interaction_name = self.request.uri[1:]
 
         try:
-            response = self.sender.send_message(interaction_name, self.request.body.decode())
+            message_id, response = self.sender.send_message(interaction_name, self.request.body.decode())
 
-            logging.debug("Message sent. Received response: %s", response)
+            logging.debug("Message sent with ID '%s'. Received response: %s", message_id, response)
 
             self.set_header("Content-Type", "text/xml")
             self.write(response)

--- a/mhs-reference-implementation/mhs/handler/tests/messages/ebxml_ack.xml
+++ b/mhs-reference-implementation/mhs/handler/tests/messages/ebxml_ack.xml
@@ -5,7 +5,7 @@
     <soap:Header>
         <eb:MessageHeader eb:version="2.0" soap:mustUnderstand="1">
             <eb:From>
-                <eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+                <eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">FROM-PARTY-ID</eb:PartyId>
             </eb:From>
             <eb:To>
                 <eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
@@ -25,7 +25,7 @@
             <eb:Timestamp>2012-03-15T06:51:08Z</eb:Timestamp>
             <eb:RefToMessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:RefToMessageId>
             <eb:From>
-                <eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+                <eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">FROM-PARTY-ID</eb:PartyId>
             </eb:From>
         </eb:Acknowledgment>
     </soap:Header>

--- a/mhs-reference-implementation/mhs/handler/tests/messages/ebxml_request.msg
+++ b/mhs-reference-implementation/mhs/handler/tests/messages/ebxml_request.msg
@@ -20,6 +20,7 @@ Content-Transfer-Encoding: 8bit
 		<eb:MessageData>
 			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
 			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>B4D38C15-4981-4366-BDE9-8F56EDC4AB72</eb:RefToMessageId>
 		</eb:MessageData>
         <eb:DuplicateElimination/>
     </eb:MessageHeader>
@@ -42,6 +43,5 @@ Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
 Content-Type: text/xml; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3">
-</hl7:MCCI_IN010000UK13>
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
 ----=_MIME-Boundary--

--- a/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
@@ -45,16 +45,16 @@ class TestAsyncResponseHandler(AsyncHTTPTestCase):
     def test_post(self, mock_get_uuid, mock_get_timestamp):
         mock_get_uuid.return_value = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
         mock_get_timestamp.return_value = "2012-03-15T06:51:08Z"
-        expected_response = FileUtilities.get_file_string(str(self.message_dir / EXPECTED_RESPONSE_FILE))
+        expected_ack_response = FileUtilities.get_file_string(str(self.message_dir / EXPECTED_RESPONSE_FILE))
         request_body = FileUtilities.get_file_string(str(self.message_dir / REQUEST_FILE))
         mock_callback = Mock()
         self.callbacks[REF_TO_MESSAGE_ID] = mock_callback
 
-        response = self.fetch("/", method="POST", body=request_body, headers=CONTENT_TYPE_HEADERS)
+        ack_response = self.fetch("/", method="POST", body=request_body, headers=CONTENT_TYPE_HEADERS)
 
-        self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], "text/xml")
-        XmlUtilities.assert_xml_equal(expected_response, response.body)
+        self.assertEqual(ack_response.code, 200)
+        self.assertEqual(ack_response.headers["Content-Type"], "text/xml")
+        XmlUtilities.assert_xml_equal(expected_ack_response, ack_response.body)
         mock_callback.assert_called_with(EXPECTED_MESSAGE)
 
     def test_post_no_callback(self):

--- a/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
@@ -15,6 +15,7 @@ from utilities.xml_utilities import XmlUtilities
 MESSAGES_DIR = "messages"
 REQUEST_FILE = "ebxml_request.msg"
 EXPECTED_RESPONSE_FILE = "ebxml_ack.xml"
+FROM_PARTY_ID = "FROM-PARTY-ID"
 CONTENT_TYPE_HEADERS = {"Content-Type": 'multipart/related; boundary="--=_MIME-Boundary"'}
 REF_TO_MESSAGE_ID = "B4D38C15-4981-4366-BDE9-8F56EDC4AB72"
 EXPECTED_MESSAGE = '<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>'
@@ -35,7 +36,8 @@ class TestAsyncResponseHandler(AsyncHTTPTestCase):
         message_parser = EbXmlRequestMessageParser()
         return Application([
             (r".*", AsyncResponseHandler,
-             dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=self.callbacks))
+             dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=self.callbacks,
+                  party_id=FROM_PARTY_ID))
         ])
 
     @patch.object(MessageUtilities, "get_timestamp")

--- a/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_async_response_handler.py
@@ -1,13 +1,13 @@
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import Application
 
 from mhs.builder.ebxml_ack_message_builder import EbXmlAckMessageBuilder
-from mhs.parser.ebxml_message_parser import EbXmlRequestMessageParser
 from mhs.handler.async_response_handler import AsyncResponseHandler
+from mhs.parser.ebxml_message_parser import EbXmlRequestMessageParser
 from utilities.file_utilities import FileUtilities
 from utilities.message_utilities import MessageUtilities
 from utilities.xml_utilities import XmlUtilities
@@ -15,6 +15,9 @@ from utilities.xml_utilities import XmlUtilities
 MESSAGES_DIR = "messages"
 REQUEST_FILE = "ebxml_request.msg"
 EXPECTED_RESPONSE_FILE = "ebxml_ack.xml"
+CONTENT_TYPE_HEADERS = {"Content-Type": 'multipart/related; boundary="--=_MIME-Boundary"'}
+REF_TO_MESSAGE_ID = "B4D38C15-4981-4366-BDE9-8F56EDC4AB72"
+EXPECTED_MESSAGE = '<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>'
 
 
 class TestAsyncResponseHandler(AsyncHTTPTestCase):
@@ -23,11 +26,16 @@ class TestAsyncResponseHandler(AsyncHTTPTestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     message_dir = Path(current_dir) / MESSAGES_DIR
 
+    def setUp(self):
+        self.callbacks = {}
+        super().setUp()
+
     def get_app(self):
         ack_builder = EbXmlAckMessageBuilder()
         message_parser = EbXmlRequestMessageParser()
         return Application([
-            (r".*", AsyncResponseHandler, dict(ack_builder=ack_builder, message_parser=message_parser))
+            (r".*", AsyncResponseHandler,
+             dict(ack_builder=ack_builder, message_parser=message_parser, callbacks=self.callbacks))
         ])
 
     @patch.object(MessageUtilities, "get_timestamp")
@@ -37,10 +45,21 @@ class TestAsyncResponseHandler(AsyncHTTPTestCase):
         mock_get_timestamp.return_value = "2012-03-15T06:51:08Z"
         expected_response = FileUtilities.get_file_string(str(self.message_dir / EXPECTED_RESPONSE_FILE))
         request_body = FileUtilities.get_file_string(str(self.message_dir / REQUEST_FILE))
+        mock_callback = Mock()
+        self.callbacks[REF_TO_MESSAGE_ID] = mock_callback
 
-        headers = {"Content-Type": 'multipart/related; boundary="--=_MIME-Boundary"'}
-        response = self.fetch("/", method="POST", body=request_body, headers=headers)
+        response = self.fetch("/", method="POST", body=request_body, headers=CONTENT_TYPE_HEADERS)
 
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers["Content-Type"], "text/xml")
         XmlUtilities.assert_xml_equal(expected_response, response.body)
+        mock_callback.assert_called_with(EXPECTED_MESSAGE)
+
+    def test_post_no_callback(self):
+        # If there is no callback registered for the message ID the response is in reference to, an HTTP 500 should be
+        # returned.
+        request_body = FileUtilities.get_file_string(str(self.message_dir / REQUEST_FILE))
+
+        response = self.fetch("/", method="POST", body=request_body, headers=CONTENT_TYPE_HEADERS)
+
+        self.assertEqual(response.code, 500)

--- a/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
@@ -6,6 +6,8 @@ from tornado.web import Application
 from mhs.handler.client_request_handler import ClientRequestHandler
 from mhs.sender.sender import UnknownInteractionError
 
+MOCK_UUID = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+
 
 class TestAsyncResponseHandler(AsyncHTTPTestCase):
 
@@ -19,7 +21,7 @@ class TestAsyncResponseHandler(AsyncHTTPTestCase):
         interaction_name = "interaction"
         request_body = "A request"
         expected_response = "Hello world!"
-        self.sender.send_message.return_value = expected_response
+        self.sender.send_message.return_value = MOCK_UUID, expected_response
 
         response = self.fetch(f"/{interaction_name}", method="POST", body=request_body)
 

--- a/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
@@ -21,7 +21,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_synchronous_message(self):
         expected_response = "Hello world!"
-        self.sender.build_message.return_value = None, REQUEST_BODY
+        self.sender.prepare_message.return_value = None, REQUEST_BODY
         self.sender.send_message.return_value = expected_response
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body=REQUEST_BODY)
@@ -32,7 +32,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
         self.sender.send_message.assert_called_with(INTERACTION_NAME, REQUEST_BODY)
 
     def test_post_with_invalid_interaction_name(self):
-        self.sender.build_message.side_effect = UnknownInteractionError(INTERACTION_NAME)
+        self.sender.prepare_message.side_effect = UnknownInteractionError(INTERACTION_NAME)
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")
 
@@ -40,7 +40,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_asynchronous_message_times_out(self):
         # An request that results in an asynchronous message should time out if no asynchronous response is received.
-        self.sender.build_message.return_value = MOCK_UUID, "ebXML request"
+        self.sender.prepare_message.return_value = MOCK_UUID, "ebXML request"
         self.sender.send_message.return_value = "Hello world!"
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")

--- a/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
@@ -7,34 +7,40 @@ from mhs.handler.client_request_handler import ClientRequestHandler
 from mhs.sender.sender import UnknownInteractionError
 
 MOCK_UUID = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
+INTERACTION_NAME = "interaction"
+REQUEST_BODY = "A request"
 
 
-class TestAsyncResponseHandler(AsyncHTTPTestCase):
+class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def get_app(self):
         self.sender = Mock()
         return Application([
-            (r"/.*", ClientRequestHandler, dict(sender=self.sender))
+            (r"/.*", ClientRequestHandler, dict(sender=self.sender, callbacks={}, async_timeout=1))
         ])
 
-    def test_post(self):
-        interaction_name = "interaction"
-        request_body = "A request"
+    def test_post_synchronous_message(self):
         expected_response = "Hello world!"
-        self.sender.send_message.return_value = MOCK_UUID, expected_response
+        self.sender.send_message.return_value = None, expected_response
 
-        response = self.fetch(f"/{interaction_name}", method="POST", body=request_body)
+        response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body=REQUEST_BODY)
 
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers["Content-Type"], "text/xml")
         self.assertEqual(response.body.decode(), expected_response)
-        self.sender.send_message.assert_called_with(interaction_name, request_body)
+        self.sender.send_message.assert_called_with(INTERACTION_NAME, REQUEST_BODY)
 
     def test_post_with_invalid_interaction_name(self):
-        interaction_name = "invalid"
-        request_body = "A request"
-        self.sender.send_message.side_effect = UnknownInteractionError(interaction_name)
+        self.sender.send_message.side_effect = UnknownInteractionError(INTERACTION_NAME)
 
-        response = self.fetch(f"/{interaction_name}", method="POST", body=request_body)
+        response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")
 
         self.assertEqual(response.code, 404)
+
+    def test_post_asynchronous_message_times_out(self):
+        # An request that results in an asynchronous message should time out if no asynchronous response is received.
+        self.sender.send_message.return_value = MOCK_UUID, "Hello world!"
+
+        response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")
+
+        self.assertEqual(response.code, 500)

--- a/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
@@ -21,7 +21,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_synchronous_message(self):
         expected_response = "Hello world!"
-        self.sender.prepare_message.return_value = None, REQUEST_BODY
+        self.sender.prepare_message.return_value = False, None, REQUEST_BODY
         self.sender.send_message.return_value = expected_response
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body=REQUEST_BODY)
@@ -40,7 +40,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_asynchronous_message_times_out(self):
         # An request that results in an asynchronous message should time out if no asynchronous response is received.
-        self.sender.prepare_message.return_value = MOCK_UUID, "ebXML request"
+        self.sender.prepare_message.return_value = True, MOCK_UUID, "ebXML request"
         self.sender.send_message.return_value = "Hello world!"
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")

--- a/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
+++ b/mhs-reference-implementation/mhs/handler/tests/test_client_request_handler.py
@@ -21,7 +21,8 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_synchronous_message(self):
         expected_response = "Hello world!"
-        self.sender.send_message.return_value = None, expected_response
+        self.sender.build_message.return_value = None, REQUEST_BODY
+        self.sender.send_message.return_value = expected_response
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body=REQUEST_BODY)
 
@@ -31,7 +32,7 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
         self.sender.send_message.assert_called_with(INTERACTION_NAME, REQUEST_BODY)
 
     def test_post_with_invalid_interaction_name(self):
-        self.sender.send_message.side_effect = UnknownInteractionError(INTERACTION_NAME)
+        self.sender.build_message.side_effect = UnknownInteractionError(INTERACTION_NAME)
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")
 
@@ -39,7 +40,8 @@ class TestClientRequestHandler(AsyncHTTPTestCase):
 
     def test_post_asynchronous_message_times_out(self):
         # An request that results in an asynchronous message should time out if no asynchronous response is received.
-        self.sender.send_message.return_value = MOCK_UUID, "Hello world!"
+        self.sender.build_message.return_value = MOCK_UUID, "ebXML request"
+        self.sender.send_message.return_value = "Hello world!"
 
         response = self.fetch(f"/{INTERACTION_NAME}", method="POST", body="A request")
 

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -6,8 +6,6 @@ from mhs.builder.ebxml_message_builder import CONVERSATION_ID, FROM_PARTY_ID
 from mhs.builder.ebxml_request_message_builder import MESSAGE
 from utilities.message_utilities import MessageUtilities
 
-PARTY_ID = "A91424-9199121"
-
 ASYNC_RESPONSE_EXPECTED = 'async_response_expected'
 
 
@@ -23,17 +21,19 @@ class UnknownInteractionError(Exception):
 
 
 class Sender:
-    def __init__(self, interactions_config, message_builder, transport):
+    def __init__(self, interactions_config, message_builder, transport, party_id):
         """Create a new Sender that uses the specified dependencies to load config, build a message and send it.
 
         :param interactions_config: The object that can be used to obtain interaction-specific configuration details.
         :param message_builder: The message builder that can be used to build a message.
         :param transport: The transport that can be used to send messages.
+        :param party_id: The party ID of this MHS. Sent in ebXML requests.
         """
 
         self.interactions_config = interactions_config
         self.message_builder = message_builder
         self.transport = transport
+        self.party_id = party_id
 
     def send_message(self, interaction_name, message_to_send) -> Tuple[str, str]:
         """Send the specified message for the interaction named.
@@ -69,7 +69,7 @@ class Sender:
         wrapper.
         """
         context = copy.deepcopy(interaction_details)
-        context[FROM_PARTY_ID] = PARTY_ID
+        context[FROM_PARTY_ID] = self.party_id
 
         conversation_id = MessageUtilities.get_uuid()
         context[CONVERSATION_ID] = conversation_id

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -8,7 +8,7 @@ from utilities.message_utilities import MessageUtilities
 
 PARTY_ID = "A91424-9199121"
 
-WRAPPER_REQUIRED = 'ebxml_wrapper_required'
+ASYNC_RESPONSE_EXPECTED = 'async_response_expected'
 
 
 class UnknownInteractionError(Exception):
@@ -40,8 +40,8 @@ class Sender:
 
         :param interaction_name: The name of the interaction the message is related to.
         :param message_to_send: A string representing the message to be sent.
-        :return: A tuple containing the ID of the message sent (if one was generated) and the content of the response
-        received
+        :return: A tuple containing the ID of the message sent (if an asynchronous response is expected) and the
+        content of the response received.
         :raises: An UnknownInteractionError if the interaction_name specified was not found.
         """
 
@@ -49,11 +49,11 @@ class Sender:
         if not interaction_details:
             raise UnknownInteractionError(interaction_name)
 
-        requires_ebxml_wrapper = interaction_details[WRAPPER_REQUIRED]
-        message_id = None
-        if requires_ebxml_wrapper:
+        async_pattern = interaction_details[ASYNC_RESPONSE_EXPECTED]
+        if async_pattern:
             message_id, message = self._wrap_message_in_ebxml(interaction_details, message_to_send)
         else:
+            message_id = None
             message = message_to_send
 
         response = self.transport.make_request(interaction_details, message)

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -41,7 +41,7 @@ class Sender:
         :param interaction_name: The name of the interaction the message is related to.
         :param message_to_send: A string representing the message to be sent.
         :return: A tuple containing the ID of the message sent (if an asynchronous response is expected) and the
-        content of the response received.
+        content of the response received. The message ID will be None if no asynchronous response is expected.
         :raises: An UnknownInteractionError if the interaction_name specified was not found.
         """
 

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -35,7 +35,7 @@ class Sender:
         self.transport = transport
         self.party_id = party_id
 
-    def build_message(self, interaction_name: str, content: str) -> Tuple[str, str]:
+    def prepare_message(self, interaction_name: str, content: str) -> Tuple[str, str]:
         """Build a message for the specified interaction. Wraps the provided content if required.
 
         :param interaction_name: The name of the interaction the message is related to.
@@ -45,8 +45,8 @@ class Sender:
         """
         interaction_details = self._get_interaction_details(interaction_name)
 
-        async_pattern = interaction_details[ASYNC_RESPONSE_EXPECTED]
-        if async_pattern:
+        is_async = interaction_details[ASYNC_RESPONSE_EXPECTED]
+        if is_async:
             message_id, message = self._wrap_message_in_ebxml(interaction_details, content)
         else:
             message_id = None

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -35,36 +35,54 @@ class Sender:
         self.transport = transport
         self.party_id = party_id
 
-    def send_message(self, interaction_name, message_to_send) -> Tuple[str, str]:
-        """Send the specified message for the interaction named.
+    def build_message(self, interaction_name: str, content: str) -> Tuple[str, str]:
+        """Build a message for the specified interaction. Wraps the provided content if required.
 
         :param interaction_name: The name of the interaction the message is related to.
-        :param message_to_send: A string representing the message to be sent.
-        :return: A tuple containing the ID of the message sent (if an asynchronous response is expected) and the
-        content of the response received. The message ID will be None if no asynchronous response is expected.
-        :raises: An UnknownInteractionError if the interaction_name specified was not found.
+        :param content: The message content to be sent.
+        :return: A tuple containing the ID of the message (if an asynchronous response is expected) and the content of
+        the response received. The message ID will be None if no asynchronous response is expected.
         """
-
-        interaction_details = self.interactions_config.get_interaction_details(interaction_name)
-        if not interaction_details:
-            raise UnknownInteractionError(interaction_name)
+        interaction_details = self._get_interaction_details(interaction_name)
 
         async_pattern = interaction_details[ASYNC_RESPONSE_EXPECTED]
         if async_pattern:
-            message_id, message = self._wrap_message_in_ebxml(interaction_details, message_to_send)
+            message_id, message = self._wrap_message_in_ebxml(interaction_details, content)
         else:
             message_id = None
-            message = message_to_send
+            message = content
 
+        return message_id, message
+
+    def send_message(self, interaction_name: str, message: str) -> str:
+        """Send the provided message for the interaction named. Returns the response received immediately, but note that
+        if the interaction will result in an asynchronous response, this will simply be the acknowledgement of the
+        request.
+
+        :param interaction_name: The name of the interaction the message is related to.
+        :param message: A string representing the message to be sent.
+        :return: A string containing the immediate response to the message sent.
+        :raises: An UnknownInteractionError if the interaction_name specified was not found.
+        """
+
+        interaction_details = self._get_interaction_details(interaction_name)
         response = self.transport.make_request(interaction_details, message)
+        logging.debug("Message sent. Received response: %s", response)
+        return response
 
-        return message_id, response
+    def _get_interaction_details(self, interaction_name):
+        interaction_details = self.interactions_config.get_interaction_details(interaction_name)
 
-    def _wrap_message_in_ebxml(self, interaction_details: Dict[str, str], message_to_send: str) -> Tuple[str, str]:
+        if not interaction_details:
+            raise UnknownInteractionError(interaction_name)
+
+        return interaction_details
+
+    def _wrap_message_in_ebxml(self, interaction_details: Dict[str, str], content: str) -> Tuple[str, str]:
         """Wrap the specified message in an ebXML wrapper.
 
         :param interaction_details: The interaction configuration to use when building the ebXML wrapper.
-        :param message_to_send: The message to be sent.
+        :param content: The message content to be sent.
         :return: A tuple of strings representing the ID and the content of the message wrapped in the generated ebXML
         wrapper.
         """
@@ -74,7 +92,7 @@ class Sender:
         conversation_id = MessageUtilities.get_uuid()
         context[CONVERSATION_ID] = conversation_id
 
-        context[MESSAGE] = message_to_send
+        context[MESSAGE] = content
         message_id, message = self.message_builder.build_message(context)
 
         logging.debug("Generated ebXML wrapper with conversation ID '%s' and message ID '%s'", conversation_id,

--- a/mhs-reference-implementation/mhs/sender/sender.py
+++ b/mhs-reference-implementation/mhs/sender/sender.py
@@ -35,13 +35,15 @@ class Sender:
         self.transport = transport
         self.party_id = party_id
 
-    def prepare_message(self, interaction_name: str, content: str) -> Tuple[str, str]:
-        """Build a message for the specified interaction. Wraps the provided content if required.
+    def prepare_message(self, interaction_name: str, content: str) -> Tuple[bool, str, str]:
+        """Prepare a message to be sent for the specified interaction. Wraps the provided content if required.
 
         :param interaction_name: The name of the interaction the message is related to.
         :param content: The message content to be sent.
-        :return: A tuple containing the ID of the message (if an asynchronous response is expected) and the content of
-        the response received. The message ID will be None if no asynchronous response is expected.
+        :return: A tuple containing:
+        1. A flag indicating whether this message should be sent asynchronously
+        2. the ID of the message, if an asynchronous response is expected, otherwise None
+        3. The message to send
         """
         interaction_details = self._get_interaction_details(interaction_name)
 
@@ -52,7 +54,7 @@ class Sender:
             message_id = None
             message = content
 
-        return message_id, message
+        return is_async, message_id, message
 
     def send_message(self, interaction_name: str, message: str) -> str:
         """Send the provided message for the interaction named. Returns the response received immediately, but note that

--- a/mhs-reference-implementation/mhs/sender/tests/test_sender.py
+++ b/mhs-reference-implementation/mhs/sender/tests/test_sender.py
@@ -29,14 +29,15 @@ class TestSender(TestCase):
             MESSAGE: sentinel.message
         }
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
-        self.mock_message_builder.build_message.return_value = sentinel.ebxml_message
+        self.mock_message_builder.build_message.return_value = sentinel.ebxml_id, sentinel.ebxml_message
         self.mock_transport.make_request.return_value = sentinel.response
 
-        actual_response = self.sender.send_message(sentinel.interaction_name, sentinel.message)
+        actual_id, actual_response = self.sender.send_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
         self.mock_message_builder.build_message.assert_called_with(expected_context)
         self.mock_transport.make_request.assert_called_with(interaction_details, sentinel.ebxml_message)
+        self.assertIs(sentinel.ebxml_id, actual_id)
         self.assertIs(sentinel.response, actual_response)
 
     def test_send_message_without_ebxml_wrapper(self):
@@ -44,10 +45,11 @@ class TestSender(TestCase):
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
         self.mock_transport.make_request.return_value = sentinel.response
 
-        actual_response = self.sender.send_message(sentinel.interaction_name, sentinel.message)
+        actual_id, actual_response = self.sender.send_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
         self.mock_transport.make_request.assert_called_with(interaction_details, sentinel.message)
+        self.assertIsNone(actual_id)
         self.assertIs(sentinel.response, actual_response)
 
     def test_send_message_incorrect_interaction_name(self):

--- a/mhs-reference-implementation/mhs/sender/tests/test_sender.py
+++ b/mhs-reference-implementation/mhs/sender/tests/test_sender.py
@@ -18,7 +18,7 @@ class TestSender(TestCase):
         self.sender = Sender(self.mock_interactions_config, self.mock_message_builder, self.mock_transport, PARTY_ID)
 
     @patch.object(MessageUtilities, "get_uuid")
-    def test_build_async_message(self, mock_get_uuid):
+    def test_prepare_message_async(self, mock_get_uuid):
         fixed_uuid = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
         mock_get_uuid.return_value = fixed_uuid
         interaction_details = {ASYNC_RESPONSE_EXPECTED: True}
@@ -31,20 +31,22 @@ class TestSender(TestCase):
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
         self.mock_message_builder.build_message.return_value = sentinel.ebxml_id, sentinel.ebxml_message
 
-        actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
+        is_async, actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
         self.mock_message_builder.build_message.assert_called_with(expected_context)
+        self.assertTrue(is_async)
         self.assertIs(sentinel.ebxml_id, actual_id)
         self.assertIs(sentinel.ebxml_message, actual_response)
 
-    def test_build_sync_message(self):
+    def test_prepare_message_sync(self):
         interaction_details = {ASYNC_RESPONSE_EXPECTED: False}
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
 
-        actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
+        is_async, actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
+        self.assertFalse(is_async)
         self.assertIsNone(actual_id)
         self.assertIs(sentinel.message, actual_response)
 

--- a/mhs-reference-implementation/mhs/sender/tests/test_sender.py
+++ b/mhs-reference-implementation/mhs/sender/tests/test_sender.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, sentinel, patch
 
 from mhs.builder.ebxml_message_builder import CONVERSATION_ID, FROM_PARTY_ID
 from mhs.builder.ebxml_request_message_builder import MESSAGE
-from mhs.sender.sender import Sender, WRAPPER_REQUIRED, UnknownInteractionError
+from mhs.sender.sender import Sender, ASYNC_RESPONSE_EXPECTED, UnknownInteractionError
 from utilities.message_utilities import MessageUtilities
 
 EXPECTED_PARTY_ID = "A91424-9199121"
@@ -21,9 +21,9 @@ class TestSender(TestCase):
     def test_send_message_with_ebxml_wrapper(self, mock_get_uuid):
         fixed_uuid = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
         mock_get_uuid.return_value = fixed_uuid
-        interaction_details = {WRAPPER_REQUIRED: True}
+        interaction_details = {ASYNC_RESPONSE_EXPECTED: True}
         expected_context = {
-            WRAPPER_REQUIRED: True,
+            ASYNC_RESPONSE_EXPECTED: True,
             FROM_PARTY_ID: EXPECTED_PARTY_ID,
             CONVERSATION_ID: fixed_uuid,
             MESSAGE: sentinel.message
@@ -41,7 +41,7 @@ class TestSender(TestCase):
         self.assertIs(sentinel.response, actual_response)
 
     def test_send_message_without_ebxml_wrapper(self):
-        interaction_details = {WRAPPER_REQUIRED: False}
+        interaction_details = {ASYNC_RESPONSE_EXPECTED: False}
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
         self.mock_transport.make_request.return_value = sentinel.response
 

--- a/mhs-reference-implementation/mhs/sender/tests/test_sender.py
+++ b/mhs-reference-implementation/mhs/sender/tests/test_sender.py
@@ -31,7 +31,7 @@ class TestSender(TestCase):
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
         self.mock_message_builder.build_message.return_value = sentinel.ebxml_id, sentinel.ebxml_message
 
-        actual_id, actual_response = self.sender.build_message(sentinel.interaction_name, sentinel.message)
+        actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
         self.mock_message_builder.build_message.assert_called_with(expected_context)
@@ -42,7 +42,7 @@ class TestSender(TestCase):
         interaction_details = {ASYNC_RESPONSE_EXPECTED: False}
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
 
-        actual_id, actual_response = self.sender.build_message(sentinel.interaction_name, sentinel.message)
+        actual_id, actual_response = self.sender.prepare_message(sentinel.interaction_name, sentinel.message)
 
         self.mock_interactions_config.get_interaction_details.assert_called_with(sentinel.interaction_name)
         self.assertIsNone(actual_id)
@@ -52,7 +52,7 @@ class TestSender(TestCase):
         self.mock_interactions_config.get_interaction_details.return_value = None
 
         with (self.assertRaises(UnknownInteractionError)):
-            self.sender.build_message("unknown_interaction", "message")
+            self.sender.prepare_message("unknown_interaction", "message")
 
     def test_sender(self):
         self.mock_interactions_config.get_interaction_details.return_value = sentinel.interaction_details

--- a/mhs-reference-implementation/mhs/sender/tests/test_sender.py
+++ b/mhs-reference-implementation/mhs/sender/tests/test_sender.py
@@ -6,7 +6,7 @@ from mhs.builder.ebxml_request_message_builder import MESSAGE
 from mhs.sender.sender import Sender, ASYNC_RESPONSE_EXPECTED, UnknownInteractionError
 from utilities.message_utilities import MessageUtilities
 
-EXPECTED_PARTY_ID = "A91424-9199121"
+PARTY_ID = "PARTY-ID"
 
 
 class TestSender(TestCase):
@@ -15,7 +15,7 @@ class TestSender(TestCase):
         self.mock_message_builder = Mock()
         self.mock_transport = Mock()
 
-        self.sender = Sender(self.mock_interactions_config, self.mock_message_builder, self.mock_transport)
+        self.sender = Sender(self.mock_interactions_config, self.mock_message_builder, self.mock_transport, PARTY_ID)
 
     @patch.object(MessageUtilities, "get_uuid")
     def test_send_message_with_ebxml_wrapper(self, mock_get_uuid):
@@ -24,7 +24,7 @@ class TestSender(TestCase):
         interaction_details = {ASYNC_RESPONSE_EXPECTED: True}
         expected_context = {
             ASYNC_RESPONSE_EXPECTED: True,
-            FROM_PARTY_ID: EXPECTED_PARTY_ID,
+            FROM_PARTY_ID: PARTY_ID,
             CONVERSATION_ID: fixed_uuid,
             MESSAGE: sentinel.message
         }


### PR DESCRIPTION
This PR implements a sync-async wrapper for the MHS reference implementation.

If the interaction requested is configured as an asynchronous one, the `ClientRequestHandler` does this by registering a callback (one of its own methods) in a shared dictionary and then 'pausing' the inbound request by waiting on an [`Event` from the tornado.locks package](https://www.tornadoweb.org/en/stable/locks.html#tornado.locks.Event). Then, when the `AsyncResponseHandler` receives the asynchronous response, it retrieves the callback from the dictionary and calls it, passing the received message payload (which is returned on the original request). This callback notifies the original thread to stop waiting and the response received is returned in response to the original request. If no asynchronous response is received after a certain timeout, the original request returns an error.

I've verified that this works as expected when running against Opentest, and the "GP Summary upload successful" message is returned for GP summary upload requests and the NHS number is returned for a (synchronous) NHS number query.

Other points of note:
- `TestClientRequestHandler` is missing a method that tests the asynchronous messaging pattern. This is because the addition of the sync-async wrapper means that it can no longer be tested with a single HTTP request. I plan to investigate the implementation of a mock spine server that will send the required asynchronous responses, but do not want to delay this PR while I do this
- I have updated `EbXmlMessageBuilder` so that it returns the message ID of the message built, as this is used as the key to tie asynchronous responses to the original requests
- I have extracted the party key of the MHS node from a constant in `Sender` to `main.py` and added details to the README of setting it to your specific value
