### PR TITLE
Feature/RT55 - Cache Adapter

### DIFF
--- a/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
+++ b/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
@@ -23,7 +23,7 @@ class AbstractMHSCacheAdaptor(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def add_cache_value(self, ods_code: str, interaction_id: str, value) -> None:
+    async def add_cache_value(self, ods_code: str, interaction_id: str, value: Dict) -> None:
         """
         Adds a value to the cache, recording the input time used to determine when values have expired
         """

--- a/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
+++ b/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
@@ -1,33 +1,30 @@
 import abc
+from typing import Optional, Dict
+
+FIFTEEN_MINUTES_IN_SECONDS = 900
 
 
 class AbstractMHSCacheAdaptor(abc.ABC):
 
-    def __init__(self, expiry_time=15):
+    def __init__(self, expiry_time=FIFTEEN_MINUTES_IN_SECONDS):
         """
-        :param expiry_time: Time for a value to expire in minutes
+        :param expiry_time: Time for a value to expire in seconds
         """
+        if expiry_time < 0:
+            raise ValueError('Expiry time must not be non-negative')
         self.expiry_time = expiry_time
-        pass
 
     @abc.abstractmethod
-    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str):
+    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str) -> Optional[Dict]:
         """
         Given a key the cache should return either the cached value or None if the value is not found or if the value is
         out of date
-        :param ods_code:
-        :param interaction_id:
-        :return:
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def add_cache_value(self, ods_code: str, interaction_id: str, value):
+    def add_cache_value(self, ods_code: str, interaction_id: str, value) -> None:
         """
-
-        :param ods_code:
-        :param interaction_id:
-        :param value:
-        :return:
+        Adds a value to the cache, recording the input time used to determine when values have expired
         """
         raise NotImplementedError()

--- a/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
+++ b/mhs-reference-implementation/mhs/routing/abstract_cache_adapter.py
@@ -1,0 +1,33 @@
+import abc
+
+
+class AbstractMHSCacheAdaptor(abc.ABC):
+
+    def __init__(self, expiry_time=15):
+        """
+        :param expiry_time: Time for a value to expire in minutes
+        """
+        self.expiry_time = expiry_time
+        pass
+
+    @abc.abstractmethod
+    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str):
+        """
+        Given a key the cache should return either the cached value or None if the value is not found or if the value is
+        out of date
+        :param ods_code:
+        :param interaction_id:
+        :return:
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def add_cache_value(self, ods_code: str, interaction_id: str, value):
+        """
+
+        :param ods_code:
+        :param interaction_id:
+        :param value:
+        :return:
+        """
+        raise NotImplementedError()

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 FIFTEEN_MINUTES_IN_SECONDS = 900
 
 
-def _generate_key(ods_code: str, interaction_id: str):
+def _generate_key(ods_code: str, interaction_id: str) -> str:
     return ods_code + interaction_id
 
 
@@ -36,7 +36,7 @@ class DictionaryCache(aca.AbstractMHSCacheAdaptor):
 
     def _is_value_expired(self, key: str) -> bool:
         """
-        A private method to check if the value associated with the given key has expired
+        Checks if the value associated with the given key has expired
         """
         current_time = time.time()
         insert_time = self.cache[key]['time']

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -1,5 +1,6 @@
 import mhs.routing.abstract_cache_adapter as ACA
 import time
+from typing import Dict, Optional
 
 FIFTEEN_MINUTES_IN_SECONDS = 900
 
@@ -10,32 +11,33 @@ def _generate_key(ods_code: str, interaction_id: str):
 
 class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
 
-    def __init__(self, expiry_time=FIFTEEN_MINUTES_IN_SECONDS):
+    def __init__(self, expiry_time: float = FIFTEEN_MINUTES_IN_SECONDS):
         if expiry_time < 0:
             raise ValueError('Invalid expiry time, must be non-negative')
         self.cache = {}
         super().__init__(expiry_time)
 
-    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str):
+    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str) -> Optional[Dict]:
         key = _generate_key(ods_code, interaction_id)
 
         if key in self.cache and not self._is_value_expired(key):
             if self._is_value_expired(key):
                 self.cache[key] = None
+                del self.cache[key]
                 return None
             else:
                 return self.cache[key]['value']
 
         return None
 
-    def _is_value_expired(self, key: str):
+    def _is_value_expired(self, key: str) -> bool:
         current_time = time.time()
         insert_time = self.cache[key]['time']
         if current_time - insert_time > self.expiry_time:
             return True
         return False
 
-    async def add_cache_value(self, ods_code: str, interaction_id: str, value):
+    async def add_cache_value(self, ods_code: str, interaction_id: str, value) -> None:
         key = _generate_key(ods_code, interaction_id)
         insert_time = time.time()
         self.cache[key] = {

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -6,7 +6,7 @@ FIFTEEN_MINUTES_IN_SECONDS = 900
 
 
 def _generate_key(ods_code: str, interaction_id: str) -> str:
-    return ods_code + interaction_id
+    return ods_code + '-' + interaction_id
 
 
 class DictionaryCache(aca.AbstractMHSCacheAdaptor):

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -1,6 +1,8 @@
 import mhs.routing.abstract_cache_adapter as ACA
 import time
 
+FIFTEEN_MINUTES_IN_SECONDS = 900
+
 
 def _generate_key(ods_code: str, interaction_id: str):
     return ods_code + interaction_id
@@ -8,7 +10,7 @@ def _generate_key(ods_code: str, interaction_id: str):
 
 class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
 
-    def __init__(self, expiry_time=15):
+    def __init__(self, expiry_time=FIFTEEN_MINUTES_IN_SECONDS):
         if expiry_time < 0:
             raise ValueError('Invalid expiry time, must be non-negative')
         self.cache = {}
@@ -17,8 +19,8 @@ class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
     async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str):
         key = _generate_key(ods_code, interaction_id)
 
-        if key in self.cache and not self._value_is_expired(key):
-            if self._value_is_expired(key):
+        if key in self.cache and not self._is_value_expired(key):
+            if self._is_value_expired(key):
                 self.cache[key] = None
                 return None
             else:
@@ -26,7 +28,7 @@ class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
 
         return None
 
-    def _value_is_expired(self, key: str):
+    def _is_value_expired(self, key: str):
         current_time = time.time()
         insert_time = self.cache[key]['time']
         if current_time - insert_time > self.expiry_time:

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -24,9 +24,8 @@ class DictionaryCache(aca.AbstractMHSCacheAdaptor):
         """
         key = _generate_key(ods_code, interaction_id)
 
-        if key in self.cache and not self._is_value_expired(key):
+        if key in self.cache:
             if self._is_value_expired(key):
-                self.cache[key] = None
                 del self.cache[key]
                 return None
             else:

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -1,4 +1,4 @@
-import mhs.routing.abstract_cache_adapter as ACA
+import mhs.routing.abstract_cache_adapter as aca
 import time
 from typing import Dict, Optional
 
@@ -9,7 +9,7 @@ def _generate_key(ods_code: str, interaction_id: str):
     return ods_code + interaction_id
 
 
-class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
+class DictionaryCache(aca.AbstractMHSCacheAdaptor):
 
     def __init__(self, expiry_time: float = FIFTEEN_MINUTES_IN_SECONDS):
         if expiry_time < 0:
@@ -18,6 +18,10 @@ class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
         super().__init__(expiry_time)
 
     async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str) -> Optional[Dict]:
+        """
+        Returns a value for the given ods code/interaction id, checks are performed here to ensure the TTL is not
+        exceeded, returns None if the key is expired or not found
+        """
         key = _generate_key(ods_code, interaction_id)
 
         if key in self.cache and not self._is_value_expired(key):
@@ -31,6 +35,9 @@ class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
         return None
 
     def _is_value_expired(self, key: str) -> bool:
+        """
+        A private method to check if the value associated with the given key has expired
+        """
         current_time = time.time()
         insert_time = self.cache[key]['time']
         if current_time - insert_time > self.expiry_time:
@@ -38,6 +45,13 @@ class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
         return False
 
     async def add_cache_value(self, ods_code: str, interaction_id: str, value) -> None:
+        """
+        Adds a value to the cache, recording the time the value was added
+        :param ods_code:
+        :param interaction_id:
+        :param value:
+        :return:
+        """
         key = _generate_key(ods_code, interaction_id)
         insert_time = time.time()
         self.cache[key] = {

--- a/mhs-reference-implementation/mhs/routing/dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/dictionary_cache.py
@@ -1,0 +1,42 @@
+import mhs.routing.abstract_cache_adapter as ACA
+import time
+
+
+def _generate_key(ods_code: str, interaction_id: str):
+    return ods_code + interaction_id
+
+
+class DictionaryCache(ACA.AbstractMHSCacheAdaptor):
+
+    def __init__(self, expiry_time=15):
+        if expiry_time < 0:
+            raise ValueError('Invalid expiry time, must be non-negative')
+        self.cache = {}
+        super().__init__(expiry_time)
+
+    async def retrieve_mhs_attributes_value(self, ods_code: str, interaction_id: str):
+        key = _generate_key(ods_code, interaction_id)
+
+        if key in self.cache and not self._value_is_expired(key):
+            if self._value_is_expired(key):
+                self.cache[key] = None
+                return None
+            else:
+                return self.cache[key]['value']
+
+        return None
+
+    def _value_is_expired(self, key: str):
+        current_time = time.time()
+        insert_time = self.cache[key]['time']
+        if current_time - insert_time > self.expiry_time:
+            return True
+        return False
+
+    async def add_cache_value(self, ods_code: str, interaction_id: str, value):
+        key = _generate_key(ods_code, interaction_id)
+        insert_time = time.time()
+        self.cache[key] = {
+            'time': insert_time,
+            'value': value
+        }

--- a/mhs-reference-implementation/mhs/routing/sds_handler.py
+++ b/mhs-reference-implementation/mhs/routing/sds_handler.py
@@ -1,13 +1,23 @@
 import mhs.routing.sds as sds
+from mhs.routing import abstract_cache_adapter
 
 
 class MHSAttributeLookupHandler:
 
-    def __init__(self, client: sds.SDSClient):
+    def __init__(self, client: sds.SDSClient, cache: abstract_cache_adapter.AbstractMHSCacheAdaptor):
         if not client:
             raise ValueError('sds client required')
+        if not cache:
+            raise ValueError('No cache supplied')
+        self.cache = cache
         self.sds_client = client
 
-    async def retrieve_mhs_attributes(self, org_code, interaction_id):
-        endpoint_details = await self.sds_client.get_mhs_details(org_code, interaction_id)
+    async def retrieve_mhs_attributes(self, ods_code, interaction_id):
+        cache_value = await self.cache.retrieve_mhs_attributes_value(ods_code, interaction_id)
+        if cache_value:
+            return cache_value
+
+        endpoint_details = await self.sds_client.get_mhs_details(ods_code, interaction_id)
+
+        await self.cache.add_cache_value(ods_code, interaction_id, endpoint_details)
         return endpoint_details

--- a/mhs-reference-implementation/mhs/routing/sds_handler.py
+++ b/mhs-reference-implementation/mhs/routing/sds_handler.py
@@ -1,10 +1,14 @@
+import logging
 import mhs.routing.sds as sds
-from mhs.routing import abstract_cache_adapter
+from mhs.routing import abstract_cache_adapter as aca
+from typing import Dict
+
+logger = logging.getLogger(__name__)
 
 
 class MHSAttributeLookupHandler:
 
-    def __init__(self, client: sds.SDSClient, cache: abstract_cache_adapter.AbstractMHSCacheAdaptor):
+    def __init__(self, client: sds.SDSClient, cache: aca.AbstractMHSCacheAdaptor):
         if not client:
             raise ValueError('sds client required')
         if not cache:
@@ -12,12 +16,14 @@ class MHSAttributeLookupHandler:
         self.cache = cache
         self.sds_client = client
 
-    async def retrieve_mhs_attributes(self, ods_code, interaction_id):
+    async def retrieve_mhs_attributes(self, ods_code, interaction_id) -> Dict:
         cache_value = await self.cache.retrieve_mhs_attributes_value(ods_code, interaction_id)
         if cache_value:
+            logger.info(f'MHS details found in cache for ods code: {ods_code} & interaction id: {interaction_id}')
             return cache_value
 
         endpoint_details = await self.sds_client.get_mhs_details(ods_code, interaction_id)
-
+        logger.info(f'MHS details obtained from sds, adding to cache for ods code: {ods_code} '
+                    f'interaction id: {interaction_id}')
         await self.cache.add_cache_value(ods_code, interaction_id, endpoint_details)
         return endpoint_details

--- a/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+
 import mhs.routing.dictionary_cache as dict_cache
 from utilities.test_utilities import async_test
 import time
@@ -25,8 +27,8 @@ class TestDictionaryCache(unittest.TestCase):
         self.assertEqual(value, "check123")
 
     @async_test
-    async def test_timeout(self):
-        cache = dict_cache.DictionaryCache(1)  # Set timeout to 1m
+    async def test_cache_entry_not_expired(self):
+        cache = dict_cache.DictionaryCache(1)  # Set timeout to 1s
         await cache.add_cache_value("code", "int", "check123")
 
         value = await cache.retrieve_mhs_attributes_value("code", "int")
@@ -34,42 +36,49 @@ class TestDictionaryCache(unittest.TestCase):
         self.assertIsNotNone(value)
         self.assertEqual(value, "check123")
 
+    @patch('time.time')
     @async_test
-    async def test_message_should_timeout(self):
+    async def test_message_should_timeout(self, patched_time):
         half_second = 0.5
+        patched_time.return_value = 1
+
         cache = dict_cache.DictionaryCache(half_second)
         await cache.add_cache_value("code", "int", "check123")
 
-        time.sleep(1)
+        patched_time.return_value = 1.6
 
         value = await cache.retrieve_mhs_attributes_value("code", "int")
 
         self.assertIsNone(value)
 
+    @patch('time.time')
     @async_test
-    async def test_multiple_timeout(self):
+    async def test_multiple_timeout(self, patched_time):
         cache = dict_cache.DictionaryCache(2)
+        patched_time.return_value = 1
         await cache.add_cache_value("code", "int", "check123")
 
-        time.sleep(1)
+        patched_time.return_value = 2
 
         value = await cache.retrieve_mhs_attributes_value("code", "int")
         self.assertEqual(value, "check123")  # Check value in cache
 
-        time.sleep(1.5)  # wait for value to expire in cache
+        patched_time.return_value = 3.5  # value should expire in cache
 
         value = await cache.retrieve_mhs_attributes_value("code", "int")
         self.assertIsNone(value)
 
+    @patch('time.time')
     @async_test
-    async def test_ttl_does_not_change_on_read(self):
+    async def test_ttl_does_not_change_on_read(self, patched_time):
         cache = dict_cache.DictionaryCache()
+        patched_time.return_value = 1
 
         await cache.add_cache_value("code", "int", "check123")
-        insert_time = cache.cache['codeint']['time']
+        insert_time = cache.cache['code-int']['time']
 
         await cache.retrieve_mhs_attributes_value("code", "int")
-        self.assertEqual(insert_time, cache.cache['codeint']['time'])
+        self.assertEqual(insert_time, cache.cache['code-int']['time'])
 
     @async_test
     async def test_invalid_timeout(self):

--- a/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
@@ -1,21 +1,21 @@
-from unittest import TestCase
-import mhs.routing.dictionary_cache as Cache
+import unittest
+import mhs.routing.dictionary_cache as dict_cache
 from utilities.test_utilities import async_test
 import time
 
 
-class TestDictionaryCache(TestCase):
+class TestDictionaryCache(unittest.TestCase):
 
     @async_test
     async def test_get_empty_value(self):
-        cache = Cache.DictionaryCache()
+        cache = dict_cache.DictionaryCache()
         value = await cache.retrieve_mhs_attributes_value("ods", "interaction")
 
         self.assertIsNone(value)
 
     @async_test
     async def test_get_basic_value(self):
-        cache = Cache.DictionaryCache()
+        cache = dict_cache.DictionaryCache()
         # Check cache is empty first
         self.assertTrue(not cache.cache)
 
@@ -27,7 +27,7 @@ class TestDictionaryCache(TestCase):
 
     @async_test
     async def test_timeout(self):
-        cache = Cache.DictionaryCache(1)  # Set timeout to 1m
+        cache = dict_cache.DictionaryCache(1)  # Set timeout to 1m
         await cache.add_cache_value("code", "int", "check123")
 
         value = await cache.retrieve_mhs_attributes_value("code", "int")
@@ -38,7 +38,7 @@ class TestDictionaryCache(TestCase):
     @async_test
     async def test_message_should_timeout(self):
         half_second = 0.5
-        cache = Cache.DictionaryCache(half_second)
+        cache = dict_cache.DictionaryCache(half_second)
         await cache.add_cache_value("code", "int", "check123")
 
         time.sleep(1)
@@ -49,7 +49,7 @@ class TestDictionaryCache(TestCase):
 
     @async_test
     async def test_multiple_timeout(self):
-        cache = Cache.DictionaryCache(2)
+        cache = dict_cache.DictionaryCache(2)
         await cache.add_cache_value("code", "int", "check123")
 
         time.sleep(1)
@@ -64,7 +64,7 @@ class TestDictionaryCache(TestCase):
 
     @async_test
     async def test_ttl_does_not_change_on_read(self):
-        cache = Cache.DictionaryCache()
+        cache = dict_cache.DictionaryCache()
 
         await cache.add_cache_value("code", "int", "check123")
         insert_time = cache.cache['codeint']['time']
@@ -75,4 +75,4 @@ class TestDictionaryCache(TestCase):
     @async_test
     async def test_invalid_timeout(self):
         with self.assertRaises(ValueError):
-            Cache.DictionaryCache(-1)
+            dict_cache.DictionaryCache(-1)

--- a/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
@@ -1,0 +1,78 @@
+from unittest import TestCase
+import mhs.routing.dictionary_cache as Cache
+from utilities.test_utilities import async_test
+import time
+
+
+class TestDictionaryCache(TestCase):
+
+    @async_test
+    async def test_get_empty_value(self):
+        cache = Cache.DictionaryCache()
+        value = await cache.retrieve_mhs_attributes_value("ods", "interaction")
+
+        self.assertIsNone(value)
+
+    @async_test
+    async def test_get_basic_value(self):
+        cache = Cache.DictionaryCache()
+        # Check cache is empty first
+        self.assertTrue(not cache.cache)
+
+        await cache.add_cache_value("code", "int", "check123")
+        value = await cache.retrieve_mhs_attributes_value("code", "int")
+
+        self.assertIsNotNone(value)
+        self.assertEqual(value, "check123")
+
+    @async_test
+    async def test_timeout(self):
+        cache = Cache.DictionaryCache(1)  # Set timeout to 1m
+        await cache.add_cache_value("code", "int", "check123")
+
+        value = await cache.retrieve_mhs_attributes_value("code", "int")
+
+        self.assertIsNotNone(value)
+        self.assertEqual(value, "check123")
+
+    @async_test
+    async def test_message_should_timeout(self):
+        half_second = 1.0 / 120
+        cache = Cache.DictionaryCache(half_second)
+        await cache.add_cache_value("code", "int", "check123")
+
+        time.sleep(1)
+
+        value = await cache.retrieve_mhs_attributes_value("code", "int")
+
+        self.assertIsNone(value)
+
+    @async_test
+    async def test_multiple_timeout(self):
+        cache = Cache.DictionaryCache(2)
+        await cache.add_cache_value("code", "int", "check123")
+
+        time.sleep(1)
+
+        value = await cache.retrieve_mhs_attributes_value("code", "int")
+        self.assertEqual(value, "check123")  # Check value in cache
+
+        time.sleep(1.5)  # wait for value to expire in cache
+
+        value = await cache.retrieve_mhs_attributes_value("code", "int")
+        self.assertIsNone(value)
+
+    @async_test
+    async def test_ttl_does_not_change_on_read(self):
+        cache = Cache.DictionaryCache()
+
+        await cache.add_cache_value("code", "int", "check123")
+        insert_time = cache.cache['codeint']['time']
+
+        await cache.retrieve_mhs_attributes_value("code", "int")
+        self.assertEqual(insert_time, cache.cache['codeint']['time'])
+
+    @async_test
+    async def test_invalid_timeout(self):
+        with self.assertRaises(ValueError):
+            Cache.DictionaryCache(-1)

--- a/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
@@ -37,7 +37,7 @@ class TestDictionaryCache(TestCase):
 
     @async_test
     async def test_message_should_timeout(self):
-        half_second = 1.0 / 120
+        half_second = 0.5
         cache = Cache.DictionaryCache(half_second)
         await cache.add_cache_value("code", "int", "check123")
 

--- a/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_dictionary_cache.py
@@ -16,7 +16,6 @@ class TestDictionaryCache(unittest.TestCase):
     @async_test
     async def test_get_basic_value(self):
         cache = dict_cache.DictionaryCache()
-        # Check cache is empty first
         self.assertTrue(not cache.cache)
 
         await cache.add_cache_value("code", "int", "check123")

--- a/mhs-reference-implementation/mhs/routing/tests/test_sds_handler.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_sds_handler.py
@@ -66,13 +66,10 @@ class TestMHSAttributeLookupHandler(TestCase):
 
     @async_test
     async def test_value_added_to_cache(self):
-        handler = sds.MHSAttributeLookupHandler(mocks.mocked_sds_client(), self.cache)
-        handler.sds_client = mocks.mocked_sds_client()
+        handler = sds.MHSAttributeLookupHandler(mocks.mocked_sds_client(), MagicMock())
+
         future = asyncio.Future()
         future.set_result(None)
-
-        handler.cache.add_cache_value = MagicMock()
-        handler.cache.retrieve_mhs_attributes_value = MagicMock()
 
         handler.cache.retrieve_mhs_attributes_value.return_value = future
         handler.cache.add_cache_value.return_value = future

--- a/mhs-reference-implementation/mhs/routing/tests/test_sds_handler.py
+++ b/mhs-reference-implementation/mhs/routing/tests/test_sds_handler.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import mhs.routing.sds_handler as sds
 import mhs.routing.tests.ldap_mocks as mocks
 from utilities.test_utilities import async_test
-from mhs.routing import dictionary_cache as dc
+import mhs.routing.dictionary_cache as dc
 
 NHS_SERVICES_BASE = "ou=services, o=nhs"
 
@@ -52,7 +52,7 @@ class TestMHSAttributeLookupHandler(TestCase):
         for key, value in expected_mhs_attributes.items():
             self.assertEqual(value, attributes[key])
 
-        # Assert exact number of attributes, minus the unique values
+        # Assert exact number of attributes
         self.assertEqual(len(attributes), len(expected_mhs_attributes))
 
     @async_test


### PR DESCRIPTION
This includes an interface for a cache used by the `MHSAttributeLookupHandler` to avoid constant lookups to the SDS. Changes include:
- AttributeLookupHandler now takes an `AbstractCacheAdaptor` as a part of the constructor.
- `retrieve_mhs_attributes` in the lookup handler now queries the queue before calling the sds client
- A dictionary-based implementation of the `AbstractCacheAdaptor` has been provided 