### PR TITLE
RT-83 Add code coverage for unittests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
                     sh label: 'Running unit tests', script: 'pipenv run unittests-cov'
                     sh label: 'Displaying code coverage report', script: 'pipenv run coverage-report'
                     sh label: 'Exporting code coverage report', script: 'pipenv run coverage-report-xml'
-                    cobertura coberturaReportFile: '**/coverage.xml''
+                    cobertura coberturaReportFile: '**/coverage.xml'
                }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,10 @@ pipeline {
         stage('Unit Tests') {
             steps {
                 dir('mhs-reference-implementation') {
-                    sh label: 'Installing dependencies', script: 'pipenv install --deploy --ignore-pipfile'
-                    sh label: 'Running unit tests', script: 'pipenv run unittests'
+                    sh label: 'Installing dependencies', script: 'pipenv install --dev --deploy --ignore-pipfile'
+                    sh label: 'Running unit tests', script: 'pipenv run unittests-cov'
+                    sh label: 'Displaying code coverage report', script: 'pipenv run coverage-report'
+                    sh label: 'Exporting code coverage report', script: 'pipenv run coverage-report-xml'
                }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
                     sh label: 'Running unit tests', script: 'pipenv run unittests-cov'
                     sh label: 'Displaying code coverage report', script: 'pipenv run coverage-report'
                     sh label: 'Exporting code coverage report', script: 'pipenv run coverage-report-xml'
+                    cobertura coberturaReportFile: '**/coverage.xml''
                }
             }
         }

--- a/mhs-reference-implementation/.coveragerc
+++ b/mhs-reference-implementation/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+branch = True
+source = .
+omit =
+    selenium_tests/*
+    */tests/*

--- a/mhs-reference-implementation/Pipfile
+++ b/mhs-reference-implementation/Pipfile
@@ -20,5 +20,6 @@ unittests = 'python -m unittest -v'
 unittests-cov = 'coverage run -m unittest -v'
 coverage-report = 'coverage report'
 coverage-report-xml = 'coverage xml'
+coverage-report-html = 'coverage html'
 inttests = 'python -m unittest discover -p "int_*" -v'
 mhs = "python main.py"

--- a/mhs-reference-implementation/Pipfile
+++ b/mhs-reference-implementation/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+coverage = "~=4.5"
 
 [packages]
 integration-adaptors-common = {editable = true,path = "./../common"}
@@ -16,5 +17,8 @@ python_version = "3.7"
 
 [scripts]
 unittests = 'python -m unittest -v'
+unittests-cov = 'coverage run -m unittest -v'
+coverage-report = 'coverage report'
+coverage-report-xml = 'coverage xml'
 inttests = 'python -m unittest discover -p "int_*" -v'
 mhs = "python main.py"

--- a/mhs-reference-implementation/Pipfile.lock
+++ b/mhs-reference-implementation/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55ef3ca275ab652b135d1fc45f7dab2dacb036be03f0162f4d48e297a82f7e90"
+            "sha256": "5a52c784d3f6973b16a552c7b99faa80a812a80a95c2ed228f790922bdb300bd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -120,5 +120,43 @@
             "version": "==1.25.3"
         }
     },
-    "develop": {}
+    "develop": {
+        "coverage": {
+            "hashes": [
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+            ],
+            "index": "pypi",
+            "version": "==4.5.3"
+        }
+    }
 }

--- a/pipeline/packer/jenkins-master/plugins.txt
+++ b/pipeline/packer/jenkins-master/plugins.txt
@@ -76,3 +76,4 @@ github-api:1.95
 momentjs:1.1.1
 jdk-tool:1.2
 credentials-binding:1.19
+cobertura:1.14


### PR DESCRIPTION
- Run code coverage for unittests
- Report the results in the Jenkins STDOUT log
- Generate a `coverage.xml` file that Sonarqube can use once we set it up