### PR TITLE
RT-91 Add workaround for certs with old signature algs

### DIFF
--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -40,6 +40,12 @@
     {
       "type": "shell",
       "inline": [
+        "sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
         "pip install pipenv",
         "cd {{user `app_dir`}}/{{user `mhs_dir`}}",
         "pipenv install --deploy --ignore-pipfile"

--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -11,7 +11,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3-slim",
+      "image": "python:3-slim-stretch",
       "commit": true,
       "changes": [
         "EXPOSE 80 443",
@@ -40,7 +40,7 @@
     {
       "type": "shell",
       "inline": [
-        "sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
+        "# sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
       ]
     },
     {

--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -40,7 +40,7 @@
     {
       "type": "shell",
       "inline": [
-        "sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
+        "sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
       ]
     },
     {

--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -40,7 +40,7 @@
     {
       "type": "shell",
       "inline": [
-        "sed -i 's/SECLEVEL=2/SECLEVEL=0/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
+        "sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
       ]
     },
     {

--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -11,7 +11,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3-slim-stretch",
+      "image": "python:3-slim",
       "commit": true,
       "changes": [
         "EXPOSE 80 443",
@@ -40,7 +40,7 @@
     {
       "type": "shell",
       "inline": [
-        "# sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
+        "sed -i 's/SECLEVEL=2/SECLEVEL=1/' /etc/ssl/openssl.cnf # Temporarily lower security to workaround opentest certs with SHA1 signatures"
       ]
     },
     {


### PR DESCRIPTION
This PR is meant to get the Jenkins builds working again. It seems to deal with the issue we've been having with SSL connection issues. However, there's now an issue where the asynchronous reply from Spine doesn't come.

I've tried debugging this, but haven't made much headway. I've managed to get it working once after rebooting the AWS EC2 instance, but then as soon as I tried re-running the integration tests (without restarting anything, MHS or EC2), then the integration tests started failing again. I've checked and updated the ASID environment variable, that hasn't fixed this. I've tried running the integration tests locally, they work fine. Any other ideas as to what this could be being caused by are welcome.