### PR TITLE
RT-79 config component

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,7 @@ pipeline {
                         -var ecr_address=${DOCKER_REPOSITORY} \
                         -var task_execution_role=${TASK_EXECUTION_ROLE} \
                         -var build_id=${BUILD_TAG}
+                        -var mhs_log_level=DEBUG
                      """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,8 @@ pipeline {
                             -var cluster_id=${CLUSTER_ID} \
                             -var ecr_address=${DOCKER_REPOSITORY} \
                             -var task_execution_role=${TASK_EXECUTION_ROLE} \
-                            -var build_id=${BUILD_TAG}
+                            -var build_id=${BUILD_TAG} \
+                            -var mhs_log_level=DEBUG
                         """
                 }
             }
@@ -68,7 +69,7 @@ pipeline {
                         -var cluster_id=${CLUSTER_ID} \
                         -var ecr_address=${DOCKER_REPOSITORY} \
                         -var task_execution_role=${TASK_EXECUTION_ROLE} \
-                        -var build_id=${BUILD_TAG}
+                        -var build_id=${BUILD_TAG} \
                         -var mhs_log_level=DEBUG
                      """
             }

--- a/common/utilities/config.py
+++ b/common/utilities/config.py
@@ -1,0 +1,24 @@
+"""
+Config
+
+This module holds the config used by an application. To use this module, first
+call `setup_config` to populate `config`. Then, just get any required config
+from `config`.
+"""
+import os
+from typing import Dict
+
+config: Dict[str, str] = {}
+
+
+def setup_config(component_name: str):
+    """
+    Populate the `config` variable in this module
+
+    :param component_name: name of the component, used to find the relevant
+    environment variables to populate `config` with.
+    """
+    prefix = component_name + "_"
+    for k, v in os.environ.items():
+        if k.startswith(prefix):
+            config[k[len(prefix):]] = v

--- a/common/utilities/config.py
+++ b/common/utilities/config.py
@@ -3,8 +3,9 @@ Config
 
 This module holds the config used by an application. To use this module, first
 call `setup_config` to populate `config`. Then, just get any required config
-from `config`.
+using `get_config` (or directly use `config` for optional config).
 """
+import logging
 import os
 from typing import Dict
 
@@ -22,3 +23,18 @@ def setup_config(component_name: str):
     for k, v in os.environ.items():
         if k.startswith(prefix):
             config[k[len(prefix):]] = v
+
+
+def get_config(key: str) -> str:
+    """
+    Get config variable or error out (and log the error)
+
+    :param key: key to lookup
+    :return: the config variable
+    """
+    try:
+        return config[key]
+    except KeyError as e:
+        # Can't use IntegrationAdaptorsLogger due to circular dependency
+        logging.exception(f'Failed to get config ConfigName:"{key}" ProcessKey=CONFIG001')
+        raise e

--- a/common/utilities/config.py
+++ b/common/utilities/config.py
@@ -3,7 +3,7 @@ Config
 
 This module holds the config used by an application. To use this module, first
 call `setup_config` to populate `config`. Then, just get any required config
-using `get_config` (or directly use `config` for optional config).
+using `get_config` (or directly use `config` for more complex use cases).
 """
 import logging
 import os

--- a/common/utilities/integration_adaptors_logger.py
+++ b/common/utilities/integration_adaptors_logger.py
@@ -1,23 +1,22 @@
 import logging
 import sys
 import time
-from typing import Union
+
+from utilities import config
 
 AUDIT = 25
 
 
 # Set the logging info globally, make each module get a new logger based on that log ref we provide
-def configure_logging(log_level: Union[int, str]):
+def configure_logging():
     """
     A general method to load the overall config of the system, specifically it modifies the root handler to output
     to stdout and sets the default log levels and format. This is expected to be called once at the start of a
     application.
-
-    :param log_level threshold at which to output logs
     """
     logging.addLevelName(AUDIT, "AUDIT")
     logger = logging.getLogger()
-    logger.setLevel(log_level)
+    logger.setLevel(config.config['LOG_LEVEL'])
     handler = logging.StreamHandler(sys.stdout)
     logging.Formatter.converter = time.gmtime
     formatter = logging.Formatter('[%(asctime)s.%(msecs)03dZ] '

--- a/common/utilities/integration_adaptors_logger.py
+++ b/common/utilities/integration_adaptors_logger.py
@@ -1,20 +1,23 @@
 import logging
 import sys
 import time
+from typing import Union
 
 AUDIT = 25
 
 
 # Set the logging info globally, make each module get a new logger based on that log ref we provide
-def configure_logging():
+def configure_logging(log_level: Union[int, str]):
     """
     A general method to load the overall config of the system, specifically it modifies the root handler to output
     to stdout and sets the default log levels and format. This is expected to be called once at the start of a
     application.
+
+    :param log_level threshold at which to output logs
     """
     logging.addLevelName(AUDIT, "AUDIT")
     logger = logging.getLogger()
-    logger.setLevel(logging.NOTSET)
+    logger.setLevel(log_level)
     handler = logging.StreamHandler(sys.stdout)
     logging.Formatter.converter = time.gmtime
     formatter = logging.Formatter('[%(asctime)s.%(msecs)03dZ] '

--- a/common/utilities/integration_adaptors_logger.py
+++ b/common/utilities/integration_adaptors_logger.py
@@ -16,7 +16,7 @@ def configure_logging():
     """
     logging.addLevelName(AUDIT, "AUDIT")
     logger = logging.getLogger()
-    logger.setLevel(config.config['LOG_LEVEL'])
+    logger.setLevel(config.get_config('LOG_LEVEL'))
     handler = logging.StreamHandler(sys.stdout)
     logging.Formatter.converter = time.gmtime
     formatter = logging.Formatter('[%(asctime)s.%(msecs)03dZ] '

--- a/common/utilities/tests/test_config.py
+++ b/common/utilities/tests/test_config.py
@@ -40,10 +40,10 @@ class TestConfig(unittest.TestCase):
         mock_environ["PREFIX_LOG_LEVEL"] = "INFO"
         config.setup_config("PREFIX")
 
-        def rename_logging_handler():
+        def remove_logging_handler():
             logging.getLogger().handlers = []
 
-        self.addCleanup(rename_logging_handler)
+        self.addCleanup(remove_logging_handler)
         integration_adaptors_logger.configure_logging()
 
         with self.assertRaises(KeyError):

--- a/common/utilities/tests/test_config.py
+++ b/common/utilities/tests/test_config.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 import utilities.config as config
 
 
-@patch("utilities.config.config", new_callable=dict)
+@patch.dict(config.config)
 @patch("os.environ", new_callable=dict)
 class TestConfig(unittest.TestCase):
 
-    def test_setup_config_populates_config(self, mock_environ, _unused):
+    def test_setup_config_populates_config(self, mock_environ):
         mock_environ["PREFIX_TEST"] = "123"
         mock_environ["PREFIX_LOG_LEVEL"] = "INFO"
 
@@ -18,7 +18,7 @@ class TestConfig(unittest.TestCase):
 
         self.assertEqual({"TEST": "123", "LOG_LEVEL": "INFO"}, config.config)
 
-    def test_setup_config_filters_by_prefix(self, mock_environ, _unused):
+    def test_setup_config_filters_by_prefix(self, mock_environ):
         mock_environ["SOME_OTHER_CONFIG"] = "BLAH"
 
         config.setup_config("PREFIX")

--- a/common/utilities/tests/test_config.py
+++ b/common/utilities/tests/test_config.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import patch
+
+import utilities.config as config
+
+
+@patch("utilities.config.config", new_callable=dict)
+@patch("os.environ", new_callable=dict)
+class TestConfig(unittest.TestCase):
+
+    def test_setup_config_populates_config(self, mock_environ, _unused):
+        mock_environ["PREFIX_TEST"] = "123"
+        mock_environ["PREFIX_LOG_LEVEL"] = "INFO"
+
+        self.assertEqual({}, config.config)
+
+        config.setup_config("PREFIX")
+
+        self.assertEqual({"TEST": "123", "LOG_LEVEL": "INFO"}, config.config)
+
+    def test_setup_config_filters_by_prefix(self, mock_environ, _unused):
+        mock_environ["SOME_OTHER_CONFIG"] = "BLAH"
+
+        config.setup_config("PREFIX")
+
+        self.assertEqual({}, config.config)

--- a/common/utilities/tests/test_config.py
+++ b/common/utilities/tests/test_config.py
@@ -30,7 +30,6 @@ class TestConfig(unittest.TestCase):
 
     def test_get_config_success(self, mock_environ):
         mock_environ["PREFIX_TEST"] = "123"
-        mock_environ["PREFIX_LOG_LEVEL"] = "INFO"
 
         config.setup_config("PREFIX")
 

--- a/common/utilities/tests/test_logger.py
+++ b/common/utilities/tests/test_logger.py
@@ -1,6 +1,6 @@
 import io
-import os
 import logging
+import os
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from utilities import integration_adaptors_logger as log
@@ -27,7 +27,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_custom_audit_level(self, mock_stdout):
-        log.configure_logging()
+        log.configure_logging(log.AUDIT)
         log.IntegrationAdaptorsLogger('TES') \
             .audit('100', '{There Will Be No Spaces Today}',
                    {'There Will Be No Spaces Today': 'wow qwe'}, correlation_id=2)
@@ -39,8 +39,16 @@ class TestLogger(TestCase):
         self.assertIn('ProcessKey=TES100', output)
 
     @patch('sys.stdout', new_callable=io.StringIO)
+    def test_log_threshold(self, mock_stdout):
+        log.configure_logging(log.AUDIT)
+        log.IntegrationAdaptorsLogger('TES').info('100', 'Test message')
+
+        output = mock_stdout.getvalue()
+        self.assertEqual("", output)
+
+    @patch('sys.stdout', new_callable=io.StringIO)
     def test_format_and_write(self, mock_std):
-        log.configure_logging()
+        log.configure_logging(logging.INFO)
         log.IntegrationAdaptorsLogger('SYS')._format_and_write(
             message='{yes} {no} {maybe}',
             values={'yes': 'one', 'no': 'two', 'maybe': 'three'},
@@ -63,7 +71,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_format_and_write_empty_vals(self, mock_std):
-        log.configure_logging()
+        log.configure_logging(logging.INFO)
         log.IntegrationAdaptorsLogger('SYS')._format_and_write(
             message='{yes} {no} {maybe}',
             values={'yes': 'one', 'no': 'two', 'maybe': 'three'},
@@ -107,7 +115,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_empty_values(self, mock_stdout):
-        log.configure_logging()
+        log.configure_logging(logging.INFO)
         logger = log.IntegrationAdaptorsLogger('SYS')
         with self.subTest('Empty info log'):
             logger.info('100', 'I can still log info strings without values!')

--- a/common/utilities/tests/test_logger.py
+++ b/common/utilities/tests/test_logger.py
@@ -3,9 +3,11 @@ import logging
 import os
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
-from utilities import integration_adaptors_logger as log
+
+from utilities import integration_adaptors_logger as log, config
 
 
+@patch("utilities.config.config", new={'LOG_LEVEL': 'INFO'})
 class TestLogger(TestCase):
 
     def tearDown(self) -> None:
@@ -27,7 +29,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_custom_audit_level(self, mock_stdout):
-        log.configure_logging(log.AUDIT)
+        log.configure_logging()
         log.IntegrationAdaptorsLogger('TES') \
             .audit('100', '{There Will Be No Spaces Today}',
                    {'There Will Be No Spaces Today': 'wow qwe'}, correlation_id=2)
@@ -40,7 +42,8 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_log_threshold(self, mock_stdout):
-        log.configure_logging(log.AUDIT)
+        config.config['LOG_LEVEL'] = 'AUDIT'
+        log.configure_logging()
         log.IntegrationAdaptorsLogger('TES').info('100', 'Test message')
 
         output = mock_stdout.getvalue()
@@ -48,7 +51,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_format_and_write(self, mock_std):
-        log.configure_logging(logging.INFO)
+        log.configure_logging()
         log.IntegrationAdaptorsLogger('SYS')._format_and_write(
             message='{yes} {no} {maybe}',
             values={'yes': 'one', 'no': 'two', 'maybe': 'three'},
@@ -71,7 +74,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_format_and_write_empty_vals(self, mock_std):
-        log.configure_logging(logging.INFO)
+        log.configure_logging()
         log.IntegrationAdaptorsLogger('SYS')._format_and_write(
             message='{yes} {no} {maybe}',
             values={'yes': 'one', 'no': 'two', 'maybe': 'three'},
@@ -115,7 +118,7 @@ class TestLogger(TestCase):
 
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_empty_values(self, mock_stdout):
-        log.configure_logging(logging.INFO)
+        log.configure_logging()
         logger = log.IntegrationAdaptorsLogger('SYS')
         with self.subTest('Empty info log'):
             logger.info('100', 'I can still log info strings without values!')

--- a/mhs-reference-implementation/main.py
+++ b/mhs-reference-implementation/main.py
@@ -6,6 +6,7 @@ from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from tornado.web import Application
 
+from utilities import config
 from definitions import ROOT_DIR
 from mhs.builder.ebxml_ack_message_builder import EbXmlAckMessageBuilder
 from mhs.builder.ebxml_request_message_builder import EbXmlRequestMessageBuilder
@@ -30,6 +31,8 @@ assert PARTY_ID
 
 interactions_config_file = str(data_dir / "interactions" / "interactions.json")
 
+config.setup_config("MHS")
+
 # Build the application
 interactions_config = InteractionsConfigFile(interactions_config_file)
 message_builder = EbXmlRequestMessageBuilder()
@@ -40,7 +43,7 @@ ack_builder = EbXmlAckMessageBuilder()
 message_parser = EbXmlRequestMessageParser()
 
 # Configure logging
-logging.basicConfig(format="%(asctime)s - %(levelname)s: %(message)s", level=logging.DEBUG)
+logging.basicConfig(format="%(asctime)s - %(levelname)s: %(message)s", level=config.config["LOG_LEVEL"])
 
 # Run the Tornado servers
 callbacks = {}

--- a/pipeline/terraform/test-environment/README.md
+++ b/pipeline/terraform/test-environment/README.md
@@ -4,17 +4,17 @@ application to AWS' ECS service for integration testing as part of the build pip
 
 This configuration will create a new ECS task definition referencing the Docker container image provided as a parameter
 and then create a new ECS service in a pre-existing cluster (again, provided as a parameter) which will run a single
-instance of the container image. 
+instance of the container image.
 
 ## Pre-requisites
-In order to function, this configuration expects several components to exist in the AWS account being used: 
+In order to function, this configuration expects several components to exist in the AWS account being used:
 
 - An IAM role for the 'Elastic Container Service Task' trusted entity with the built-in
   `AmazonECSTaskExecutionRolePolicy`. You can use the `ecsTaskExecutionRole` created for you automatically by AWS when
   creating a task definition from the console, if available. This ARN of this role is passed as the
   `task_execution_role` input variable.
 - An IAM role for the EC2 instance/etc. running the build pipeline. This must grant the `ecs:RegisterTaskDefinition`
-  ,`ecs:CreateService`, `iam:PassRole`, `ecs:DescribeTaskDefinition`, `ecs:DeregisterTaskDefinition`, 
+  ,`ecs:CreateService`, `iam:PassRole`, `ecs:DescribeTaskDefinition`, `ecs:DeregisterTaskDefinition`,
   `ecs:DescribeServices`, `ecs:UpdateService` & `ecs:DeleteService` permissions to the build machine.
 - A CloudWatch log group named `/ecs/test-environment`
 - An ECS Cluster - the ARN of this cluster must be passed as the `cluster_id` input variable
@@ -26,10 +26,10 @@ for details. If running this on your local machine, the simplest option is to
 [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) and run `aws configure`.
 
 Next, you will need to have built the Docker container image containing the MHS. This can be done using the
-`pipeline/packer/mhs.json` script.  
+`pipeline/packer/mhs.json` script.
 
 Once you have configured AWS authentication, you can run the following commands in this directory:
-1. `terraform init` - Initialises local Terraform settings 
+1. `terraform init` - Initialises local Terraform settings
 1. `terraform apply --var cluster_id=<cluster-arn> -var task_execution_role=<role-arn> -var build_id=<build-tag> -var ecs_address=<ecs repository> -var mhs_log_level=<log level>` - Applies the configuration from this directory and deploys
 
 You can remove the resources deployed with `terraform destroy --var cluster_id=<cluster-arn> -var ecs_address=<ecs repository> -var task_execution_role=<role-arn> -var build_id=<build-tag> -var mhs_log_level=<log level>`

--- a/pipeline/terraform/test-environment/README.md
+++ b/pipeline/terraform/test-environment/README.md
@@ -30,6 +30,6 @@ Next, you will need to have built the Docker container image containing the MHS.
 
 Once you have configured AWS authentication, you can run the following commands in this directory:
 1. `terraform init` - Initialises local Terraform settings 
-1. `terraform apply --var cluster_id=<cluster-arn> -var task_execution_role=<role-arn> -var build_id=<build-tag> -var ecs_address=<ecs repository>` - Applies the configuration from this directory and deploys
+1. `terraform apply --var cluster_id=<cluster-arn> -var task_execution_role=<role-arn> -var build_id=<build-tag> -var ecs_address=<ecs repository> -var mhs_log_level=<log level>` - Applies the configuration from this directory and deploys
 
-You can remove the resources deployed with `terraform destroy --var cluster_id=<cluster-arn> -var ecs_address=<ecs repository> -var task_execution_role=<role-arn> -var build_id=<build-tag>` 
+You can remove the resources deployed with `terraform destroy --var cluster_id=<cluster-arn> -var ecs_address=<ecs repository> -var task_execution_role=<role-arn> -var build_id=<build-tag> -var mhs_log_level=<log level>`

--- a/pipeline/terraform/test-environment/test-environment.tf
+++ b/pipeline/terraform/test-environment/test-environment.tf
@@ -31,6 +31,13 @@ resource "aws_ecs_task_definition" "test-environment-mhs-task" {
         containerPath = "/usr/src/app/mhs-reference-implementation/data/certs/"
       }]
 
+      environment = [
+        {
+          name = "MHS_LOG_LEVEL"
+          value = var.mhs_log_level
+        }
+      ]
+
       portMappings = [
         {
           containerPort = 80

--- a/pipeline/terraform/test-environment/variables.tf
+++ b/pipeline/terraform/test-environment/variables.tf
@@ -6,3 +6,4 @@ variable "cluster_id" {}
 variable "task_execution_role" {}
 variable "build_id" {}
 variable "ecr_address" {}
+variable "mhs_log_level" {}

--- a/pipeline/terraform/test-environment/variables.tf
+++ b/pipeline/terraform/test-environment/variables.tf
@@ -1,9 +1,26 @@
 variable "region" {
+  type = string
   default = "eu-west-2"
+  description = "The AWS region to deploy to."
 }
 
-variable "cluster_id" {}
-variable "task_execution_role" {}
-variable "build_id" {}
-variable "ecr_address" {}
-variable "mhs_log_level" {}
+variable "cluster_id" {
+  type = string
+  description = "The ECS cluster to deploy to."
+}
+variable "task_execution_role" {
+  type = string
+  description = "ARN of the IAM role to run the task with."
+}
+variable "build_id" {
+  type = string
+  description = "Build ID to identify the image in the ECR repo to use."
+}
+variable "ecr_address" {
+  type = string
+  description = "Address of the ECR repository to get the container from."
+}
+variable "mhs_log_level" {
+  type = string
+  description = "Log level for the MHS application."
+}


### PR DESCRIPTION
- Create a common config component and use it in mhs
- Configure the build pipeline to set the log level for the integration tests
- Change the logger to get the log level from config
  - I originally did this as 3ef57d4, then changed it to cb7719b. If people want, I can switch back to 3ef57d4, otherwise I'll leave it as-is.
- Add some docs for Terraform variables