### PR TITLE
Add a config to fix building the project with the packer docker builder on windows

### DIFF
--- a/pipeline/packer/mhs.json
+++ b/pipeline/packer/mhs.json
@@ -12,6 +12,7 @@
     {
       "type": "docker",
       "image": "python:3-slim",
+      "container_dir": "/packer-files",
       "commit": true,
       "changes": [
         "EXPOSE 80 443",


### PR DESCRIPTION
Adds a line to the builder config to fix building the project with packer 1.4.2, on a windows machine