### PR TITLE
RT-94 message packer parsing

### DIFF
--- a/common/builder/pystache_message_builder.py
+++ b/common/builder/pystache_message_builder.py
@@ -32,7 +32,7 @@ class PystacheMessageBuilder:
             logger.error('0001', 'Failed to find {Key} when generating message from {TemplateFile} . {ErrorMessage}',
                          {'Key': e.key, 'TemplateFile': self.template_file, 'ErrorMessage': str(e)})
             raise MessageGenerationError(f'Failed to find key:{e.key} when generating message from'
-                                         f' template file:{self.template_file}')
+                                         f' template file:{self.template_file}') from e
 
 
 class MessageGenerationError(Exception):

--- a/mhs/Pipfile
+++ b/mhs/Pipfile
@@ -12,6 +12,7 @@ requests = "*"
 integration-adaptors-common = {editable = true,path = "./../common"}
 ldap3 = "*"
 tornado = "*"
+defusedxml = "~=0.6"
 
 [requires]
 python_version = "3.7"

--- a/mhs/Pipfile.lock
+++ b/mhs/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a52494b22ae9a1bf9dfddd3e8195b870c77820db20f3ef2e635a88881aea314"
+            "sha256": "5a9aeb921961f62025e5d7a4197cbfe28f24c7ac7845017a52b399086d515a48"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,14 @@
             ],
             "version": "==3.0.4"
         },
+        "defusedxml": {
+            "hashes": [
+                "sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93",
+                "sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -51,39 +59,37 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:06c7616601430aa140a69f97e3116308fffe0848f543b639a5ec2e8920ae72fd",
-                "sha256:177202792f9842374a8077735c69c41a4282183f7851443d2beb8ee310720819",
-                "sha256:19317ad721ceb9e39847d11131903931e2794e447d4751ebb0d9236f1b349ff2",
-                "sha256:36d206e62f3e5dbaafd4ec692b67157e271f5da7fd925fda8515da675eace50d",
-                "sha256:387115b066c797c85f9861a9613abf50046a15aac16759bc92d04f94acfad082",
-                "sha256:3ce1c49d4b4a7bc75fb12acb3a6247bb7a91fe420542e6d671ba9187d12a12c2",
-                "sha256:4d2a5a7d6b0dbb8c37dab66a8ce09a8761409c044017721c21718659fa3365a1",
-                "sha256:58d0a1b33364d1253a88d18df6c0b2676a1746d27c969dc9e32d143a3701dda5",
-                "sha256:62a651c618b846b88fdcae0533ec23f185bb322d6c1845733f3123e8980c1d1b",
-                "sha256:69ff21064e7debc9b1b1e2eee8c2d686d042d4257186d70b338206a80c5bc5ea",
-                "sha256:7060453eba9ba59d821625c6af6a266bd68277dce6577f754d1eb9116c094266",
-                "sha256:7d26b36a9c4bce53b9cfe42e67849ae3c5c23558bc08363e53ffd6d94f4ff4d2",
-                "sha256:83b427ad2bfa0b9705e02a83d8d607d2c2f01889eb138168e462a3a052c42368",
-                "sha256:923d03c84534078386cf50193057aae98fa94cace8ea7580b74754493fda73ad",
-                "sha256:b773715609649a1a180025213f67ffdeb5a4878c784293ada300ee95a1f3257b",
-                "sha256:baff149c174e9108d4a2fee192c496711be85534eab63adb122f93e70aa35431",
-                "sha256:bca9d118b1014b4c2d19319b10a3ebed508ff649396ce1855e1c96528d9b2fa9",
-                "sha256:ce580c28845581535dc6000fc7c35fdadf8bea7ccb57d6321b044508e9ba0685",
-                "sha256:d34923a569e70224d88e6682490e24c842907ba2c948c5fd26185413cbe0cd96",
-                "sha256:dd9f0e531a049d8b35ec5e6c68a37f1ba6ec3a591415e6804cbdf652793d15d7",
-                "sha256:ecb805cbfe9102f3fd3d2ef16dfe5ae9e2d7a7dfbba92f4ff1e16ac9784dbfb0",
-                "sha256:ede9aad2197a0202caff35d417b671f5f91a3631477441076082a17c94edd846",
-                "sha256:ef2d1fc370400e0aa755aab0b20cf4f1d0e934e7fd5244f3dd4869078e4942b9",
-                "sha256:f2fec194a49bfaef42a548ee657362af5c7a640da757f6f452a35da7dd9f923c"
+                "sha256:06e5599b9c54f797a3c0f384c67705a0d621031007aa2400a6c7d17300fdb995",
+                "sha256:092237cfe4ece074401b75001a2e525fa6e1fb9d40fee8b7b132b1947d3bd2f8",
+                "sha256:0b6d49d0a26fe8207df8dd27c40b75be4deb2277173903aa76ec3e82df77cbe7",
+                "sha256:0f77061c20b4f32b1cf39e8f661c74e966344084c996e7b23c3a94e472461df0",
+                "sha256:0fef86edfa2f146b4b0ae2c6c05c3e4a8f3388b3655eafbc4aab3247f4dabb24",
+                "sha256:2f163c8844db4ed06a230ef092e2461ad01830972a896b8f3cf8b5bac70ae85d",
+                "sha256:350333190052bbfbc3222b1805b59b7979d7276e57af2257367e15a2db27082d",
+                "sha256:3b57dc5ed7b6a7d852c961f2389ca99404c2b59fd2088baec6fbaca02f688be4",
+                "sha256:3e86e5df4a8edd6f725f3c76f1d45e046d4f3aa40478092e4f5f373ad1f526e2",
+                "sha256:43dac60d10341d3e56be089cd0798b70e70d45ce32279f4c3190d8cbd71350e4",
+                "sha256:4665ee84ac8ba11d58f1ed517e29ea8536b4ae4e0c6fb6c7d3dce70abcd279f0",
+                "sha256:5033cf606a7cb559db967689b1b2e743994000f783607ba4c484e90917395ad7",
+                "sha256:75d731af05bf40f808d7716e0d26b4b02913402f861c032ce8c36efca350ae72",
+                "sha256:7720174604c7647e357566ac9e4d135c137caed5e7b01223551a4c81c8dc8b9a",
+                "sha256:b33ec641309bcea40c76c1b105f988e4e8f9a2f1ee1486aa5c0eeef33956c9bb",
+                "sha256:d1135dc0ac197242028ede085b693ba1f2bff7f0f9b91080e2540348312bfa53",
+                "sha256:d5a61e9c2322b45f259909a02b76bc98c4641214e22a37191d00c151aa9cdb9a",
+                "sha256:da22c4b17bc17dad9c8faf6d94c8fe568ac71c867a56631ab874da418fc7f8f7",
+                "sha256:da5c48ec9f8d8b5df42d328b6d1fb8d9413cd664a2367ef4f6f7cc48ee5b82c0",
+                "sha256:db2794bad21b7b30b6849b4e1537171cae8a7087711d958d69c233470dc612e7",
+                "sha256:f1c2f67df727034f94ccb590142d1d110f3dd38f638a4f1567fdd9f39892ba05",
+                "sha256:f840dddded8b046edc774c88ed8d2442cdb231a68894c42c74e3a809450fae76"
             ],
-            "version": "==4.3.4"
+            "version": "==4.4.0"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
-                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
+                "sha256:3bb81821d47b17146049e7574ab4bf1e315eb7aead30efe5d6a9ca422c9710be",
+                "sha256:b773d5c9196ffbc3a1e13bdf909d446cad80a039aa3340bcad72f395b76ebc86"
             ],
-            "version": "==0.4.5"
+            "version": "==0.4.6"
         },
         "pystache": {
             "hashes": [
@@ -123,40 +129,41 @@
     "develop": {
         "coverage": {
             "hashes": [
-                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
-                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
-                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
-                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
-                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
-                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
-                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
-                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
-                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
-                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
-                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
-                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
-                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
-                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
-                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
-                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
-                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
-                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
-                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
-                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
-                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
-                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
-                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
-                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
-                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
-                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
-                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
-                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
-                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
-                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
-                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+                "sha256:08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6",
+                "sha256:0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650",
+                "sha256:141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5",
+                "sha256:19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d",
+                "sha256:23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351",
+                "sha256:245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755",
+                "sha256:331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef",
+                "sha256:386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca",
+                "sha256:3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca",
+                "sha256:60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9",
+                "sha256:63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc",
+                "sha256:6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5",
+                "sha256:6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f",
+                "sha256:7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe",
+                "sha256:826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888",
+                "sha256:93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5",
+                "sha256:9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce",
+                "sha256:af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5",
+                "sha256:bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e",
+                "sha256:bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e",
+                "sha256:c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9",
+                "sha256:dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437",
+                "sha256:df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1",
+                "sha256:e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c",
+                "sha256:e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24",
+                "sha256:e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47",
+                "sha256:eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2",
+                "sha256:eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28",
+                "sha256:ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c",
+                "sha256:efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7",
+                "sha256:fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0",
+                "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
             ],
             "index": "pypi",
-            "version": "==4.5.3"
+            "version": "==4.5.4"
         },
         "six": {
             "hashes": [

--- a/mhs/data/templates/ebxml_ack.mustache
+++ b/mhs/data/templates/ebxml_ack.mustache
@@ -13,8 +13,8 @@
             </eb:To>
             <eb:CPAId>{{cpa_id}}</eb:CPAId>
             <eb:ConversationId>{{conversation_id}}</eb:ConversationId>
-            <eb:Service>urn:oasis:names:tc:ebxml-msg:service</eb:Service>
-            <eb:Action>Acknowledgment</eb:Action>
+            <eb:Service>{{service}}</eb:Service>
+            <eb:Action>{{action}}</eb:Action>
             <eb:MessageData>
                 <eb:MessageId>{{message_id}}</eb:MessageId>
                 <eb:Timestamp>{{received_message_timestamp}}</eb:Timestamp>

--- a/mhs/mhs/common/messages/ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_ack_envelope.py
@@ -3,7 +3,8 @@ an asynchronous request."""
 
 from __future__ import annotations
 
-from typing import Dict
+import copy
+from typing import Dict, Tuple
 
 from defusedxml import ElementTree
 
@@ -22,7 +23,15 @@ class EbxmlAckEnvelope(ebxml_envelope.EbxmlEnvelope):
 
         :param message_dictionary: The dictionary of values to use when populating the template.
         """
+        message_dictionary = copy.deepcopy(message_dictionary)
+        message_dictionary[ebxml_envelope.SERVICE] = 'urn:oasis:names:tc:ebxml-msg:service'
+        message_dictionary[ebxml_envelope.ACTION] = 'Acknowledgment'
         super().__init__(EBXML_TEMPLATE, message_dictionary)
+
+    def serialize(self) -> Tuple[str, Dict[str, str], str]:
+        message_id, http_headers, message = super().serialize()
+        http_headers['Content-Type'] = 'text/xml'
+        return message_id, http_headers, message
 
     @classmethod
     def from_string(cls, headers: Dict[str, str], message: str) -> EbxmlAckEnvelope:

--- a/mhs/mhs/common/messages/ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_ack_envelope.py
@@ -11,7 +11,6 @@ import mhs.common.messages.ebxml_envelope as ebxml_envelope
 EBXML_TEMPLATE = "ebxml_ack"
 
 RECEIVED_MESSAGE_TIMESTAMP = "received_message_timestamp"
-RECEIVED_MESSAGE_ID = "received_message_id"
 
 
 class EbxmlAckEnvelope(ebxml_envelope.EbxmlEnvelope):

--- a/mhs/mhs/common/messages/ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_ack_envelope.py
@@ -4,6 +4,7 @@ an asynchronous request."""
 from __future__ import annotations
 
 from typing import Dict
+from xml.etree import ElementTree
 
 import mhs.common.messages.ebxml_envelope as ebxml_envelope
 
@@ -31,5 +32,5 @@ class EbxmlAckEnvelope(ebxml_envelope.EbxmlEnvelope):
         :param message: The message to be parsed.
         :return: An instance of an EbxmlAckEnvelope constructed from the message.
         """
-        message_dictionary = super().parse_message(headers, message)
+        message_dictionary = super().parse_message(ElementTree.fromstring(message))
         return EbxmlAckEnvelope(message_dictionary)

--- a/mhs/mhs/common/messages/ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_ack_envelope.py
@@ -32,4 +32,5 @@ class EbxmlAckEnvelope(ebxml_envelope.EbxmlEnvelope):
         :return: An instance of an EbxmlAckEnvelope constructed from the message.
         """
         message_dictionary = super().parse_message(ElementTree.fromstring(message))
+        message_dictionary[RECEIVED_MESSAGE_TIMESTAMP] = message_dictionary.pop(ebxml_envelope.TIMESTAMP)
         return EbxmlAckEnvelope(message_dictionary)

--- a/mhs/mhs/common/messages/ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_ack_envelope.py
@@ -4,7 +4,8 @@ an asynchronous request."""
 from __future__ import annotations
 
 from typing import Dict
-from xml.etree import ElementTree
+
+from defusedxml import ElementTree
 
 import mhs.common.messages.ebxml_envelope as ebxml_envelope
 

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -2,7 +2,7 @@
 import copy
 import pathlib
 import xml.etree.ElementTree as ElementTree
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Any, Optional
 
 import builder.pystache_message_builder as pystache_message_builder
 import definitions
@@ -45,7 +45,7 @@ class EbxmlEnvelope(envelope.Envelope):
         {'name': RECEIVED_MESSAGE_ID, 'element_name': 'RefToMessageId', 'parent': 'MessageData'}
     ]
 
-    def __init__(self, template_file, message_dictionary: Dict[str, str]):
+    def __init__(self, template_file: str, message_dictionary: Dict[str, Any]):
         """Create a new EbxmlEnvelope that populates the specified template file with the provided dictionary.
 
         :param template_file: The template file to populate with values.
@@ -94,7 +94,7 @@ class EbxmlEnvelope(envelope.Envelope):
         return extracted_values
 
     @staticmethod
-    def _path_to_ebxml_element(name, parent=None):
+    def _path_to_ebxml_element(name: str, parent: str = None) -> str:
         path = ".//"
 
         if parent is not None:
@@ -105,7 +105,8 @@ class EbxmlEnvelope(envelope.Envelope):
         return path
 
     @staticmethod
-    def _extract_ebxml_value(xml_tree: ElementTree.Element, element_name, parent=None, required=False):
+    def _extract_ebxml_value(xml_tree: ElementTree.Element, element_name: str, parent: str = None,
+                             required: bool = False) -> Optional[ElementTree.Element]:
         xpath = EbxmlEnvelope._path_to_ebxml_element(element_name, parent=parent)
         value = xml_tree.find(xpath, namespaces=NAMESPACES)
         if value is None and required:
@@ -115,7 +116,8 @@ class EbxmlEnvelope(envelope.Envelope):
         return value
 
     @staticmethod
-    def _extract_ebxml_text_value(xml_tree: ElementTree.Element, element_name, parent=None, required=False):
+    def _extract_ebxml_text_value(xml_tree: ElementTree.Element, element_name: str, parent: str = None,
+                                  required: bool = False) -> Optional[str]:
         value = EbxmlEnvelope._extract_ebxml_value(xml_tree, element_name, parent, required)
         text = None
 
@@ -125,7 +127,8 @@ class EbxmlEnvelope(envelope.Envelope):
         return text
 
     @staticmethod
-    def _extract_attribute(xml_tree, element_name, attribute_namespace, attribute_name, values_dict, key):
+    def _extract_attribute(xml_tree: ElementTree.Element, element_name: str, attribute_namespace: Dict[str, str],
+                           attribute_name: str, values_dict: Dict[str, Any], key: str):
         xpath = EbxmlEnvelope._path_to_ebxml_element(element_name)
         element = xml_tree.find(xpath, NAMESPACES)
         if element is not None:
@@ -138,12 +141,12 @@ class EbxmlEnvelope(envelope.Envelope):
                                         f"EbXML message") from e
 
     @staticmethod
-    def _add_if_present(values_dict, key, value):
+    def _add_if_present(values_dict: Dict[str, Any], key: str, value: Any):
         if value is not None:
             values_dict[key] = value
 
     @staticmethod
-    def _add_flag(values_dict, key, value):
+    def _add_flag(values_dict: Dict[str, Any], key: str, value: Optional[Any]):
         if value is not None:
             values_dict[key] = True
         else:

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -1,8 +1,10 @@
 """This module defines the envelope used to wrap asynchronous messages to be sent to a remote MHS."""
 import copy
 import pathlib
-import xml.etree.ElementTree as ElementTree
 from typing import Dict, Tuple, Any, Optional
+from xml.etree.ElementTree import Element
+
+import defusedxml.ElementTree as ElementTree
 
 import builder.pystache_message_builder as pystache_message_builder
 import definitions
@@ -76,7 +78,7 @@ class EbxmlEnvelope(envelope.Envelope):
         return message_id, self.message_builder.build_message(ebxml_message_dictionary)
 
     @staticmethod
-    def parse_message(xml_tree: ElementTree.Element) -> Dict[str, str]:
+    def parse_message(xml_tree: Element) -> Dict[str, str]:
         """Extract a dictionary of values from the provided xml Element tree.
 
         :param xml_tree: The xml tree to extract values from
@@ -105,8 +107,8 @@ class EbxmlEnvelope(envelope.Envelope):
         return path
 
     @staticmethod
-    def _extract_ebxml_value(xml_tree: ElementTree.Element, element_name: str, parent: str = None,
-                             required: bool = False) -> Optional[ElementTree.Element]:
+    def _extract_ebxml_value(xml_tree: Element, element_name: str, parent: str = None,
+                             required: bool = False) -> Optional[Element]:
         xpath = EbxmlEnvelope._path_to_ebxml_element(element_name, parent=parent)
         value = xml_tree.find(xpath, namespaces=NAMESPACES)
         if value is None and required:
@@ -116,7 +118,7 @@ class EbxmlEnvelope(envelope.Envelope):
         return value
 
     @staticmethod
-    def _extract_ebxml_text_value(xml_tree: ElementTree.Element, element_name: str, parent: str = None,
+    def _extract_ebxml_text_value(xml_tree: Element, element_name: str, parent: str = None,
                                   required: bool = False) -> Optional[str]:
         value = EbxmlEnvelope._extract_ebxml_value(xml_tree, element_name, parent, required)
         text = None
@@ -127,7 +129,7 @@ class EbxmlEnvelope(envelope.Envelope):
         return text
 
     @staticmethod
-    def _extract_attribute(xml_tree: ElementTree.Element, element_name: str, attribute_namespace: Dict[str, str],
+    def _extract_attribute(xml_tree: Element, element_name: str, attribute_namespace: Dict[str, str],
                            attribute_name: str, values_dict: Dict[str, Any], key: str):
         xpath = EbxmlEnvelope._path_to_ebxml_element(element_name)
         element = xml_tree.find(xpath, NAMESPACES)

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -68,14 +68,12 @@ class EbxmlEnvelope(envelope.Envelope):
         return message_id, self.message_builder.build_message(ebxml_message_dictionary)
 
     @staticmethod
-    def parse_message(headers: Dict[str, str], message: str) -> Dict[str, str]:
-        """Parse the provided ebXML message and extract a dictionary of values from it.
+    def parse_message(xml_tree: ElementTree.Element) -> Dict[str, str]:
+        """Extract a dictionary of values from the provided xml Element tree.
 
-        :param headers A dictionary of headers received with the message.
-        :param message: The message to be parsed.
+        :param xml_tree: The xml tree to extract values from
         :return: A dictionary of values extracted from the message.
         """
-        xml_tree = ElementTree.fromstring(message)
         extracted_values = {}
 
         EbxmlEnvelope._add_if_present(extracted_values, FROM_PARTY_ID,

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -98,9 +98,9 @@ class EbxmlEnvelope(envelope.Envelope):
         path = ".//"
 
         if parent is not None:
-            path += EBXML_NAMESPACE + ":" + parent + "/"
+            path += f"{EBXML_NAMESPACE}:{parent}/"
 
-        path += EBXML_NAMESPACE + ":" + name
+        path += f"{EBXML_NAMESPACE}:{name}"
 
         return path
 

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -23,10 +23,6 @@ ACTION = "action"
 MESSAGE_ID = 'message_id'
 TIMESTAMP = 'timestamp'
 REF_TO_MESSAGE_ID = "ref_to_message_id"
-DUPLICATE_ELIMINATION = "duplicate_elimination"
-ACK_REQUESTED = "ack_requested"
-ACK_SOAP_ACTOR = "ack_soap_actor"
-SYNC_REPLY = "sync_reply"
 
 EBXML_NAMESPACE = "eb"
 SOAP_NAMESPACE = "SOAP"
@@ -97,14 +93,6 @@ class EbxmlEnvelope(envelope.Envelope):
         EbxmlEnvelope._add_if_present(extracted_values, REF_TO_MESSAGE_ID,
                                       EbxmlEnvelope._extract_ebxml_text_value(xml_tree, "RefToMessageId",
                                                                               parent="MessageData"))
-        EbxmlEnvelope._add_flag_if_present(extracted_values, DUPLICATE_ELIMINATION,
-                                           EbxmlEnvelope._extract_ebxml_value(xml_tree, "DuplicateElimination"))
-        EbxmlEnvelope._add_flag_if_present(extracted_values, SYNC_REPLY,
-                                           EbxmlEnvelope._extract_ebxml_value(xml_tree, "SyncReply"))
-        EbxmlEnvelope._add_flag_if_present(extracted_values, ACK_REQUESTED,
-                                           EbxmlEnvelope._extract_ebxml_value(xml_tree, "AckRequested"))
-        EbxmlEnvelope._extract_attribute(xml_tree, "AckRequested", SOAP_NAMESPACE, "actor", extracted_values,
-                                         ACK_SOAP_ACTOR)
 
         return extracted_values
 

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -22,7 +22,7 @@ SERVICE = "service"
 ACTION = "action"
 MESSAGE_ID = 'message_id'
 TIMESTAMP = 'timestamp'
-REF_TO_MESSAGE_ID = "ref_to_message_id"
+RECEIVED_MESSAGE_ID = "received_message_id"
 
 EBXML_NAMESPACE = "eb"
 SOAP_NAMESPACE = "SOAP"
@@ -42,7 +42,7 @@ class EbxmlEnvelope(envelope.Envelope):
         {'name': ACTION, 'element_name': 'Action', 'parent': None},
         {'name': MESSAGE_ID, 'element_name': 'MessageId', 'parent': 'MessageData'},
         {'name': TIMESTAMP, 'element_name': 'Timestamp', 'parent': 'MessageData'},
-        {'name': REF_TO_MESSAGE_ID, 'element_name': 'RefToMessageId', 'parent': 'MessageData'}
+        {'name': RECEIVED_MESSAGE_ID, 'element_name': 'RefToMessageId', 'parent': 'MessageData'}
     ]
 
     def __init__(self, template_file, message_dictionary: Dict[str, str]):

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -58,7 +58,7 @@ class EbxmlEnvelope(envelope.Envelope):
         ebxml_template_dir = str(pathlib.Path(definitions.ROOT_DIR) / TEMPLATES_DIR)
         self.message_builder = pystache_message_builder.PystacheMessageBuilder(ebxml_template_dir, template_file)
 
-    def serialize(self) -> Tuple[str, str]:
+    def serialize(self) -> Tuple[str, Dict[str, str], str]:
         """Produce a serialised representation of this ebXML message by populating a Mustache template with this
         object's properties.
 
@@ -75,7 +75,12 @@ class EbxmlEnvelope(envelope.Envelope):
         logger.info('0001', 'Creating ebXML message with {MessageId} and {Timestamp}',
                     {'MessageId': message_id, 'Timestamp': timestamp})
 
-        return message_id, self.message_builder.build_message(ebxml_message_dictionary)
+        message = self.message_builder.build_message(ebxml_message_dictionary)
+        http_headers = {
+            'charset': 'UTF-8',
+            'SOAPAction': f'{ebxml_message_dictionary[SERVICE]}/{ebxml_message_dictionary[ACTION]}'
+        }
+        return message_id, http_headers, message
 
     @staticmethod
     def parse_message(xml_tree: Element) -> Dict[str, str]:

--- a/mhs/mhs/common/messages/ebxml_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_envelope.py
@@ -131,6 +131,8 @@ class EbxmlEnvelope(envelope.Envelope):
             values_dict[key] = value
 
     @staticmethod
-    def _add_flag_if_present(values_dict, key, value):
+    def _add_flag(values_dict, key, value):
         if value is not None:
             values_dict[key] = True
+        else:
+            values_dict[key] = False

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -84,8 +84,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         :param message: The message (as a string) to be parsed.
         :return: a Message that represents the message received.
         """
-        content_type = headers[CONTENT_TYPE_HEADER_NAME]
-        content_type_header = CONTENT_TYPE_HEADER_NAME + ": " + content_type + "\r\n\r\n"
+        content_type_header = f'{CONTENT_TYPE_HEADER_NAME}: {headers[CONTENT_TYPE_HEADER_NAME]}\r\n\r\n'
 
         msg = email.message_from_string(content_type_header + message)
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -7,6 +7,7 @@ import email.message
 import email.policy
 import logging
 from typing import Dict, Tuple
+from xml.etree import ElementTree
 
 import mhs.common.messages.ebxml_envelope as ebxml_envelope
 
@@ -42,7 +43,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         """
         msg = EbxmlRequestEnvelope._parse_mime_message(headers, message)
         ebxml_part, payload_part = EbxmlRequestEnvelope._extract_message_parts(msg)
-        extracted_values = super().parse_message(headers, ebxml_part)
+        extracted_values = super().parse_message(ElementTree.fromstring(ebxml_part))
 
         if payload_part:
             extracted_values[MESSAGE] = payload_part

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -82,7 +82,8 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         msg = email.message_from_string(content_type_header + message)
 
         if msg.defects:
-            logger.warning('0002', 'Found defects in MIME message during parsing. {Defects}', {'Defects': msg.defects})
+            logger.warning('0002', 'Found defects in MIME message during parsing. {Defects}',
+                           {'Defects': str(msg.defects)})
 
         return msg
 
@@ -104,7 +105,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         for i, part in enumerate(message_parts):
             if part.defects:
                 logger.warning('0003', 'Found defects in {PartIndex} of MIME message during parsing. {Defects}',
-                               {'PartIndex': i, 'Defects': part.defects})
+                               {'PartIndex': str(i), 'Defects': str(part.defects)})
 
         ebxml_part = message_parts[0].get_payload()
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -6,7 +6,7 @@ import email
 import email.message
 import email.policy
 import logging
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Union
 from xml.etree import ElementTree
 
 from mhs.common.messages import ebxml_envelope
@@ -26,7 +26,7 @@ SYNC_REPLY = "sync_reply"
 class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
     """An envelope that contains a request to be sent asynchronously to a remote MHS."""
 
-    def __init__(self, message_dictionary: Dict[str, str]):
+    def __init__(self, message_dictionary: Dict[str, Union[str, bool]]):
         """Create a new EbxmlRequestEnvelope that populates the message with the provided dictionary.
 
         :param message_dictionary: The dictionary of values to use when populating the template.
@@ -55,7 +55,8 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         return EbxmlRequestEnvelope(extracted_values)
 
     @classmethod
-    def _extract_more_values_from_xml_tree(cls, xml_tree, extracted_values):
+    def _extract_more_values_from_xml_tree(cls, xml_tree: ElementTree.Element,
+                                           extracted_values: Dict[str, Union[str, bool]]):
         cls._add_flag(extracted_values, DUPLICATE_ELIMINATION,
                       cls._extract_ebxml_value(xml_tree, "DuplicateElimination"))
         cls._add_flag(extracted_values, SYNC_REPLY, cls._extract_ebxml_value(xml_tree, "SyncReply"))

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -77,7 +77,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         :return: a Message that represents the message received.
         """
         content_type = headers[CONTENT_TYPE_HEADER_NAME]
-        content_type_header = CONTENT_TYPE_HEADER_NAME + ": " + content_type + "\r\n"
+        content_type_header = CONTENT_TYPE_HEADER_NAME + ": " + content_type + "\r\n\r\n"
 
         msg = email.message_from_string(content_type_header + message)
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -9,7 +9,7 @@ import logging
 from typing import Dict, Tuple
 from xml.etree import ElementTree
 
-import mhs.common.messages.ebxml_envelope as ebxml_envelope
+from mhs.common.messages import ebxml_envelope
 
 EBXML_TEMPLATE = "ebxml_request"
 
@@ -21,11 +21,6 @@ DUPLICATE_ELIMINATION = "duplicate_elimination"
 ACK_REQUESTED = "ack_requested"
 ACK_SOAP_ACTOR = "ack_soap_actor"
 SYNC_REPLY = "sync_reply"
-
-
-class EbXmlParsingError(Exception):
-    """Raised when an error was encountered during parsing of an ebXML message."""
-    pass
 
 
 class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
@@ -95,7 +90,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         # (if present) must be the first additional attachment.
 
         if not msg.is_multipart():
-            raise EbXmlParsingError("Non-multipart message received!")
+            raise ebxml_envelope.EbXmlParsingError("Non-multipart message received!")
 
         message_parts = msg.get_payload()
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -6,7 +6,9 @@ import email
 import email.message
 import email.policy
 from typing import Dict, Tuple, Union
-from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+
+from defusedxml import ElementTree
 
 from mhs.common.messages import ebxml_envelope
 from utilities import integration_adaptors_logger as log
@@ -58,7 +60,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         return EbxmlRequestEnvelope(extracted_values)
 
     @classmethod
-    def _extract_more_values_from_xml_tree(cls, xml_tree: ElementTree.Element,
+    def _extract_more_values_from_xml_tree(cls, xml_tree: Element,
                                            extracted_values: Dict[str, Union[str, bool]]):
         cls._add_flag(extracted_values, DUPLICATE_ELIMINATION,
                       cls._extract_ebxml_value(xml_tree, "DuplicateElimination"))

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -61,10 +61,10 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
 
     @classmethod
     def _extract_more_values_from_xml_tree(cls, xml_tree, extracted_values):
-        cls._add_flag_if_present(extracted_values, DUPLICATE_ELIMINATION,
-                                 cls._extract_ebxml_value(xml_tree, "DuplicateElimination"))
-        cls._add_flag_if_present(extracted_values, SYNC_REPLY, cls._extract_ebxml_value(xml_tree, "SyncReply"))
-        cls._add_flag_if_present(extracted_values, ACK_REQUESTED, cls._extract_ebxml_value(xml_tree, "AckRequested"))
+        cls._add_flag(extracted_values, DUPLICATE_ELIMINATION,
+                      cls._extract_ebxml_value(xml_tree, "DuplicateElimination"))
+        cls._add_flag(extracted_values, SYNC_REPLY, cls._extract_ebxml_value(xml_tree, "SyncReply"))
+        cls._add_flag(extracted_values, ACK_REQUESTED, cls._extract_ebxml_value(xml_tree, "AckRequested"))
         cls._extract_attribute(xml_tree, "AckRequested", ebxml_envelope.SOAP_NAMESPACE, "actor", extracted_values,
                                ACK_SOAP_ACTOR)
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -83,7 +83,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
 
         if msg.defects:
             logger.warning('0002', 'Found defects in MIME message during parsing. {Defects}',
-                           {'Defects': str(msg.defects)})
+                           {'Defects': msg.defects})
 
         return msg
 
@@ -105,7 +105,7 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         for i, part in enumerate(message_parts):
             if part.defects:
                 logger.warning('0003', 'Found defects in {PartIndex} of MIME message during parsing. {Defects}',
-                               {'PartIndex': str(i), 'Defects': str(part.defects)})
+                               {'PartIndex': i, 'Defects': part.defects})
 
         ebxml_part = message_parts[0].get_payload()
 

--- a/mhs/mhs/common/messages/ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/ebxml_request_envelope.py
@@ -37,6 +37,12 @@ class EbxmlRequestEnvelope(ebxml_envelope.EbxmlEnvelope):
         """
         super().__init__(EBXML_TEMPLATE, message_dictionary)
 
+    def serialize(self) -> Tuple[str, Dict[str, str], str]:
+        message_id, http_headers, message = super().serialize()
+        http_headers['Content-Type'] = 'multipart/related; boundary="--=_MIME-Boundary"; type=text/xml; ' \
+                                       'start=ebXMLHeader@spine.nhs.uk'
+        return message_id, http_headers, message
+
     @classmethod
     def from_string(cls, headers: Dict[str, str], message: str) -> EbxmlRequestEnvelope:
         """Parse the provided message string and create an instance of an EbxmlRequestEnvelope.

--- a/mhs/mhs/common/messages/envelope.py
+++ b/mhs/mhs/common/messages/envelope.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 import abc
-from typing import Dict
+from typing import Dict, Tuple
 
 
 class Envelope(abc.ABC):
     """An envelope that contains a message to be sent to a remote MHS."""
 
     @abc.abstractmethod
-    def serialize(self):
+    def serialize(self) -> Tuple[str, Dict[str, str], str]:
         """Produce a serialised representation of this message.
 
-        :return: The serialized representation of this message.
+        :return: A tuple of: the message id, headers to send along with the message and the serialized representation
+        of the message.
         """
         pass
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
@@ -1,3 +1,4 @@
+import copy
 from unittest.mock import patch
 
 import mhs.common.messages.ebxml_ack_envelope as ebxml_ack_envelope
@@ -9,7 +10,9 @@ from utilities import message_utilities
 from utilities import xml_utilities
 
 EXPECTED_EBXML = "ebxml_ack.xml"
-EXPECTED_VALUES = test_ebxml_envelope.BASE_EXPECTED_VALUES
+
+EXPECTED_VALUES = copy.deepcopy(test_ebxml_envelope.BASE_EXPECTED_VALUES)
+EXPECTED_VALUES[ebxml_ack_envelope.RECEIVED_MESSAGE_TIMESTAMP] = EXPECTED_VALUES.pop(ebxml_envelope.TIMESTAMP)
 
 
 def get_test_message_dictionary():
@@ -82,10 +85,6 @@ class TestEbXmlAckEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
         first_message_id, first_message = envelope.serialize()
 
         parsed_message = ebxml_ack_envelope.EbxmlAckEnvelope.from_string({}, first_message)
-
-        # Atm, when parsing, we're not parsing out the request_message_timestamp.
-        parsed_message.message_dictionary[ebxml_ack_envelope.RECEIVED_MESSAGE_TIMESTAMP] = test_message_dict[
-            ebxml_ack_envelope.RECEIVED_MESSAGE_TIMESTAMP]
 
         second_message_id, second_message = parsed_message.serialize()
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
@@ -67,6 +67,5 @@ class TestEbXmlAckEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
     def test_from_string_with_no_values(self):
         message = file_utilities.FileUtilities.get_file_string(str(self.message_dir / "ebxml_header_empty.xml"))
 
-        parsed_message = ebxml_ack_envelope.EbxmlAckEnvelope.from_string({}, message)
-
-        self.assertEqual({}, parsed_message.message_dictionary)
+        with self.assertRaisesRegex(ebxml_envelope.EbXmlParsingError, "Weren't able to find required element"):
+            ebxml_ack_envelope.EbxmlAckEnvelope.from_string({}, message)

--- a/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
@@ -28,7 +28,7 @@ def get_test_message_dictionary():
     }
 
 
-class TestEbXmlAckEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
+class TestEbXmlAckEnvelope(test_ebxml_envelope.BaseTestEbxmlEnvelope):
 
     @patch.object(message_utilities.MessageUtilities, "get_timestamp")
     @patch.object(message_utilities.MessageUtilities, "get_uuid")

--- a/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
@@ -9,6 +9,7 @@ from utilities import message_utilities
 from utilities import xml_utilities
 
 EXPECTED_EBXML = "ebxml_ack.xml"
+EXPECTED_VALUES = test_ebxml_envelope.BASE_EXPECTED_VALUES
 
 
 def get_test_message_dictionary():
@@ -61,7 +62,7 @@ class TestEbXmlAckEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
 
         parsed_message = ebxml_ack_envelope.EbxmlAckEnvelope.from_string({}, message)
 
-        self.assertEqual(test_ebxml_envelope.EXPECTED_VALUES, parsed_message.message_dictionary)
+        self.assertEqual(EXPECTED_VALUES, parsed_message.message_dictionary)
 
     def test_from_string_with_no_values(self):
         message = file_utilities.FileUtilities.get_file_string(str(self.message_dir / "ebxml_header_empty.xml"))

--- a/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_ack_envelope.py
@@ -19,7 +19,7 @@ def get_test_message_dictionary():
         ebxml_envelope.CPA_ID: "S1001A1630",
         ebxml_envelope.CONVERSATION_ID: "79F49A34-9798-404C-AEC4-FD38DD81C138",
         ebxml_ack_envelope.RECEIVED_MESSAGE_TIMESTAMP: "2013-04-16T07:52:09Z",
-        ebxml_ack_envelope.RECEIVED_MESSAGE_ID: "0CDBA95F-74DA-47E9-8383-7B8E9167D146",
+        ebxml_envelope.RECEIVED_MESSAGE_ID: "0CDBA95F-74DA-47E9-8383-7B8E9167D146",
     }
 
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
@@ -18,7 +18,7 @@ BASE_EXPECTED_VALUES = {
     ebxml_envelope.SERVICE: "urn:nhs:names:services:psis",
     ebxml_envelope.ACTION: "MCCI_IN010000UK13",
     ebxml_envelope.MESSAGE_ID: "C614484E-4B10-499A-9ACD-5D645CFACF61",
-    ebxml_envelope.REF_TO_MESSAGE_ID: "F106022D-758B-49A9-A80A-8FF211C32A43",
+    ebxml_envelope.RECEIVED_MESSAGE_ID: "F106022D-758B-49A9-A80A-8FF211C32A43",
     ebxml_envelope.TIMESTAMP: "2019-05-04T20:55:16Z",
 }
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
@@ -2,7 +2,10 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
+from defusedxml import ElementTree
+
 from mhs.common.messages import ebxml_envelope
+from utilities import file_utilities
 
 EXPECTED_MESSAGES_DIR = "expected_messages"
 MESSAGE_DIR = "test_messages"
@@ -23,7 +26,22 @@ BASE_EXPECTED_VALUES = {
 }
 
 
-class TestEbxmlEnvelope(TestCase):
+class BaseTestEbxmlEnvelope(TestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     message_dir = Path(current_dir) / MESSAGE_DIR
     expected_message_dir = Path(current_dir) / EXPECTED_MESSAGES_DIR
+
+
+class TestEbxmlEnvelope(BaseTestEbxmlEnvelope):
+    def test_cant_find_optional_text_value_during_parsing(self):
+        message = file_utilities.FileUtilities.get_file_string(str(self.message_dir / "ebxml_header.xml"))
+
+        xml_tree = ElementTree.fromstring(message)
+        values_dict = {}
+        ebxml_envelope.EbxmlEnvelope._add_if_present(
+            values_dict,
+            'key',
+            ebxml_envelope.EbxmlEnvelope._extract_ebxml_text_value(xml_tree, 'nonExistentElement')
+        )
+
+        self.assertEqual({}, values_dict)

--- a/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
@@ -2,8 +2,7 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
-from  mhs.common.messages import ebxml_envelope
-from mhs.common.messages import ebxml_request_envelope
+from mhs.common.messages import ebxml_envelope
 
 EXPECTED_MESSAGES_DIR = "expected_messages"
 MESSAGE_DIR = "test_messages"

--- a/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_envelope.py
@@ -2,7 +2,8 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
-import mhs.common.messages.ebxml_envelope as ebxml_envelope
+from  mhs.common.messages import ebxml_envelope
+from mhs.common.messages import ebxml_request_envelope
 
 EXPECTED_MESSAGES_DIR = "expected_messages"
 MESSAGE_DIR = "test_messages"
@@ -10,7 +11,7 @@ MESSAGE_DIR = "test_messages"
 MOCK_UUID = "5BB171D4-53B2-4986-90CF-428BE6D157F5"
 MOCK_TIMESTAMP = "2012-03-15T06:51:08Z"
 
-EXPECTED_VALUES = {
+BASE_EXPECTED_VALUES = {
     ebxml_envelope.FROM_PARTY_ID: "YES-0000806",
     ebxml_envelope.TO_PARTY_ID: "A91424-9199121",
     ebxml_envelope.CPA_ID: "S1001A1630",
@@ -20,10 +21,6 @@ EXPECTED_VALUES = {
     ebxml_envelope.MESSAGE_ID: "C614484E-4B10-499A-9ACD-5D645CFACF61",
     ebxml_envelope.REF_TO_MESSAGE_ID: "F106022D-758B-49A9-A80A-8FF211C32A43",
     ebxml_envelope.TIMESTAMP: "2019-05-04T20:55:16Z",
-    ebxml_envelope.DUPLICATE_ELIMINATION: True,
-    ebxml_envelope.ACK_REQUESTED: True,
-    ebxml_envelope.ACK_SOAP_ACTOR: "urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH",
-    ebxml_envelope.SYNC_REPLY: True,
 }
 
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import mhs.common.messages.ebxml_envelope
 import mhs.common.messages.ebxml_envelope as ebxml_envelope
 import mhs.common.messages.ebxml_request_envelope as ebxml_request_envelope
 import mhs.common.messages.tests.test_ebxml_envelope as test_ebxml_envelope
@@ -142,7 +143,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             message = file_utilities.FileUtilities.get_file_string(
                 str(self.message_dir / "ebxml_request_no_header.msg"))
 
-            with (self.assertRaises(ebxml_request_envelope.EbXmlParsingError)):
+            with (self.assertRaises(ebxml_envelope.EbXmlParsingError)):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
 
         with self.subTest("A valid request that does not contain the optional payload MIME part"):
@@ -164,7 +165,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             self.assertEqual(expected_values_with_payload, parsed_message.message_dictionary)
 
         with self.subTest("An message that is not a multi-part MIME message"):
-            with (self.assertRaises(ebxml_request_envelope.EbXmlParsingError)):
+            with (self.assertRaises(ebxml_envelope.EbXmlParsingError)):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string({CONTENT_TYPE_HEADER_NAME: "text/plain"},
                                                                         "A message")
 
@@ -195,3 +196,11 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             parsed_message = ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
 
             self.assertEqual(expected_values_with_payload, parsed_message.message_dictionary)
+
+        with self.subTest(f'A valid request without an AckRequested SOAP actor attribute'):
+            message = file_utilities.FileUtilities.get_file_string(
+                str(self.message_dir / 'ebxml_request_no_soap_actor.msg'))
+
+            with self.assertRaisesRegex(
+                    ebxml_envelope.EbXmlParsingError, "Weren't able to find required attribute actor"):
+                ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -142,7 +142,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             message = file_utilities.FileUtilities.get_file_string(
                 str(self.message_dir / "ebxml_request_no_header.msg"))
 
-            with (self.assertRaises(ebxml_envelope.EbXmlParsingError)):
+            with self.assertRaises(ebxml_envelope.EbXmlParsingError):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
 
         with self.subTest("A valid request that does not contain the optional payload MIME part"):
@@ -164,7 +164,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             self.assertEqual(expected_values_with_payload, parsed_message.message_dictionary)
 
         with self.subTest("An message that is not a multi-part MIME message"):
-            with (self.assertRaises(ebxml_envelope.EbXmlParsingError)):
+            with self.assertRaises(ebxml_envelope.EbXmlParsingError):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string({CONTENT_TYPE_HEADER_NAME: "text/plain"},
                                                                         "A message")
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -21,6 +21,12 @@ _ADDITIONAL_EXPECTED_VALUES = {
 }
 EXPECTED_VALUES = {**test_ebxml_envelope.BASE_EXPECTED_VALUES, **_ADDITIONAL_EXPECTED_VALUES}
 
+EXPECTED_HTTP_HEADERS = {
+    'charset': 'UTF-8',
+    'SOAPAction': 'urn:nhs:names:services:pdsquery/QUPA_IN000006UK02',
+    'Content-Type': 'multipart/related; boundary="--=_MIME-Boundary"; type=text/xml; start=ebXMLHeader@spine.nhs.uk'
+}
+
 
 def get_test_message_dictionary():
     return {
@@ -65,11 +71,12 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
 
         envelope = ebxml_request_envelope.EbxmlRequestEnvelope(get_test_message_dictionary())
 
-        message_id, message = envelope.serialize()
+        message_id, http_headers, message = envelope.serialize()
 
         normalized_message = file_utilities.FileUtilities.normalize_line_endings(message)
 
         self.assertEqual(test_ebxml_envelope.MOCK_UUID, message_id)
+        self.assertEqual(EXPECTED_HTTP_HEADERS, http_headers)
         self.assertEqual(self.normalized_expected_serialized_message, normalized_message)
 
     @patch.object(message_utilities.MessageUtilities, "get_timestamp")
@@ -81,12 +88,13 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
         message_dictionary[ebxml_envelope.MESSAGE_ID] = test_ebxml_envelope.MOCK_UUID
         envelope = ebxml_request_envelope.EbxmlRequestEnvelope(message_dictionary)
 
-        message_id, message = envelope.serialize()
+        message_id, http_headers, message = envelope.serialize()
 
         normalized_message = file_utilities.FileUtilities.normalize_line_endings(message)
 
         mock_get_uuid.assert_not_called()
         self.assertEqual(test_ebxml_envelope.MOCK_UUID, message_id)
+        self.assertEqual(EXPECTED_HTTP_HEADERS, http_headers)
         self.assertEqual(self.normalized_expected_serialized_message, normalized_message)
 
     @patch.object(message_utilities.MessageUtilities, "get_timestamp")
@@ -121,11 +129,12 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
                 message_dictionary[optional_tag] = False
                 envelope = ebxml_request_envelope.EbxmlRequestEnvelope(message_dictionary)
 
-                message_id, message = envelope.serialize()
+                message_id, http_headers, message = envelope.serialize()
 
                 normalized_message = file_utilities.FileUtilities.normalize_line_endings(message)
 
                 self.assertEqual(test_ebxml_envelope.MOCK_UUID, message_id)
+                self.assertEqual(EXPECTED_HTTP_HEADERS, http_headers)
                 self.assertNotEqual(self.normalized_expected_serialized_message, normalized_message)
                 self.assertNotIn(optional_xml_tag, normalized_message)
 

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -53,7 +53,7 @@ def expected_values(message=None):
     return values
 
 
-class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
+class TestEbxmlRequestEnvelope(test_ebxml_envelope.BaseTestEbxmlEnvelope):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch
 
-import mhs.common.messages.ebxml_envelope
 import mhs.common.messages.ebxml_envelope as ebxml_envelope
 import mhs.common.messages.ebxml_request_envelope as ebxml_request_envelope
 import mhs.common.messages.tests.test_ebxml_envelope as test_ebxml_envelope

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -145,6 +145,16 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
             with self.assertRaises(ebxml_envelope.EbXmlParsingError):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
 
+        with self.subTest("A multi-part MIME message with a defect in the payload"):
+            message = file_utilities.FileUtilities.get_file_string(
+                str(self.message_dir / "ebxml_request_payload_defect.msg"))
+
+            expected_values_with_test_payload = expected_values("mock-payload")
+
+            parsed_message = ebxml_request_envelope.EbxmlRequestEnvelope.from_string(MULTIPART_MIME_HEADERS, message)
+
+            self.assertEqual(expected_values_with_test_payload, parsed_message.message_dictionary)
+
         with self.subTest("A valid request that does not contain the optional payload MIME part"):
             message = file_utilities.FileUtilities.get_file_string(
                 str(self.message_dir / "ebxml_request_no_payload.msg"))
@@ -163,7 +173,7 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
 
             self.assertEqual(expected_values_with_payload, parsed_message.message_dictionary)
 
-        with self.subTest("An message that is not a multi-part MIME message"):
+        with self.subTest("A message that is not a multi-part MIME message"):
             with self.assertRaises(ebxml_envelope.EbXmlParsingError):
                 ebxml_request_envelope.EbxmlRequestEnvelope.from_string({CONTENT_TYPE_HEADER_NAME: "text/plain"},
                                                                         "A message")

--- a/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
+++ b/mhs/mhs/common/messages/tests/test_ebxml_request_envelope.py
@@ -13,6 +13,14 @@ CONTENT_TYPE_HEADER_NAME = "Content-Type"
 MULTIPART_MIME_HEADERS = {CONTENT_TYPE_HEADER_NAME: 'multipart/related; boundary="--=_MIME-Boundary"'}
 EXPECTED_MESSAGE = '<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>'
 
+_ADDITIONAL_EXPECTED_VALUES = {
+    ebxml_request_envelope.DUPLICATE_ELIMINATION: True,
+    ebxml_request_envelope.ACK_REQUESTED: True,
+    ebxml_request_envelope.ACK_SOAP_ACTOR: "urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH",
+    ebxml_request_envelope.SYNC_REPLY: True,
+}
+EXPECTED_VALUES = {**test_ebxml_envelope.BASE_EXPECTED_VALUES, **_ADDITIONAL_EXPECTED_VALUES}
+
 
 def get_test_message_dictionary():
     return {
@@ -22,16 +30,16 @@ def get_test_message_dictionary():
         ebxml_envelope.CONVERSATION_ID: "79F49A34-9798-404C-AEC4-FD38DD81C138",
         ebxml_envelope.SERVICE: "urn:nhs:names:services:pdsquery",
         ebxml_envelope.ACTION: "QUPA_IN000006UK02",
-        ebxml_envelope.DUPLICATE_ELIMINATION: True,
-        ebxml_envelope.ACK_REQUESTED: True,
-        ebxml_envelope.ACK_SOAP_ACTOR: "urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH",
-        ebxml_envelope.SYNC_REPLY: True,
+        ebxml_request_envelope.DUPLICATE_ELIMINATION: True,
+        ebxml_request_envelope.ACK_REQUESTED: True,
+        ebxml_request_envelope.ACK_SOAP_ACTOR: "urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH",
+        ebxml_request_envelope.SYNC_REPLY: True,
         ebxml_request_envelope.MESSAGE: '<QUPA_IN000006UK02 xmlns="urn:hl7-org:v3"></QUPA_IN000006UK02>'
     }
 
 
 def expected_values(message=None):
-    values = test_ebxml_envelope.EXPECTED_VALUES.copy()
+    values = EXPECTED_VALUES.copy()
 
     if message:
         values[ebxml_request_envelope.MESSAGE] = message
@@ -103,9 +111,9 @@ class TestEbxmlRequestEnvelope(test_ebxml_envelope.TestEbxmlEnvelope):
         mock_get_timestamp.return_value = test_ebxml_envelope.MOCK_TIMESTAMP
 
         test_cases = [
-            (ebxml_envelope.DUPLICATE_ELIMINATION, 'eb:DuplicateElimination'),
-            (ebxml_envelope.ACK_REQUESTED, 'eb:AckRequested'),
-            (ebxml_envelope.SYNC_REPLY, 'eb:SyncReply')
+            (ebxml_request_envelope.DUPLICATE_ELIMINATION, 'eb:DuplicateElimination'),
+            (ebxml_request_envelope.ACK_REQUESTED, 'eb:AckRequested'),
+            (ebxml_request_envelope.SYNC_REPLY, 'eb:SyncReply')
         ]
         for optional_tag, optional_xml_tag in test_cases:
             with self.subTest(optional_tag=optional_tag):

--- a/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_ack_requested.msg
+++ b/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_ack_requested.msg
@@ -1,0 +1,46 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>F106022D-758B-49A9-A80A-8FF211C32A43</eb:RefToMessageId>
+		</eb:MessageData>
+        <eb:DuplicateElimination/>
+    </eb:MessageHeader>
+    <eb:SyncReply SOAP:mustUnderstand="1" eb:version="2.0" SOAP:actor="http://schemas.xmlsoap.org/soap/actor/next"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
+----=_MIME-Boundary--

--- a/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_duplicate_elimination.msg
+++ b/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_duplicate_elimination.msg
@@ -1,0 +1,46 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>F106022D-758B-49A9-A80A-8FF211C32A43</eb:RefToMessageId>
+		</eb:MessageData>
+    </eb:MessageHeader>
+    <eb:AckRequested SOAP:mustUnderstand="1" eb:version="2.0" eb:signed="false" SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH"/>
+    <eb:SyncReply SOAP:mustUnderstand="1" eb:version="2.0" SOAP:actor="http://schemas.xmlsoap.org/soap/actor/next"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
+----=_MIME-Boundary--

--- a/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_soap_actor.msg
+++ b/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_soap_actor.msg
@@ -1,0 +1,47 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>F106022D-758B-49A9-A80A-8FF211C32A43</eb:RefToMessageId>
+		</eb:MessageData>
+        <eb:DuplicateElimination/>
+    </eb:MessageHeader>
+    <eb:AckRequested SOAP:mustUnderstand="1" eb:version="2.0" eb:signed="false"/>
+    <eb:SyncReply SOAP:mustUnderstand="1" eb:version="2.0" SOAP:actor="http://schemas.xmlsoap.org/soap/actor/next"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
+----=_MIME-Boundary--

--- a/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_sync_reply.msg
+++ b/mhs/mhs/common/messages/tests/test_messages/ebxml_request_no_sync_reply.msg
@@ -1,0 +1,46 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>F106022D-758B-49A9-A80A-8FF211C32A43</eb:RefToMessageId>
+		</eb:MessageData>
+        <eb:DuplicateElimination/>
+    </eb:MessageHeader>
+    <eb:AckRequested SOAP:mustUnderstand="1" eb:version="2.0" eb:signed="false" SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
+----=_MIME-Boundary--

--- a/mhs/mhs/common/messages/tests/test_messages/ebxml_request_payload_defect.msg
+++ b/mhs/mhs/common/messages/tests/test_messages/ebxml_request_payload_defect.msg
@@ -1,0 +1,46 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>F106022D-758B-49A9-A80A-8FF211C32A43</eb:RefToMessageId>
+		</eb:MessageData>
+        <eb:DuplicateElimination/>
+    </eb:MessageHeader>
+    <eb:AckRequested SOAP:mustUnderstand="1" eb:version="2.0" eb:signed="false" SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH"/>
+    <eb:SyncReply SOAP:mustUnderstand="1" eb:version="2.0" SOAP:actor="http://schemas.xmlsoap.org/soap/actor/next"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+mock-payload
+----=_MIME-Boundary--

--- a/mhs/mhs/common/workflow/sync_async.py
+++ b/mhs/mhs/common/workflow/sync_async.py
@@ -101,7 +101,7 @@ class SyncAsyncWorkflow(common_synchronous.CommonSynchronousWorkflow):
         context[ebxml_request_envelope.MESSAGE] = content
         request = ebxml_request_envelope.EbxmlRequestEnvelope(context)
 
-        message_id, message = request.serialize()
+        message_id, _, message = request.serialize()
 
         logging.debug("Generated ebXML wrapper with conversation ID '%s' and message ID '%s'", conversation_id,
                       message_id)

--- a/mhs/mhs/common/workflow/tests/test_sync_async.py
+++ b/mhs/mhs/common/workflow/tests/test_sync_async.py
@@ -31,7 +31,8 @@ class TestSyncAsyncWorkflow(TestCase):
             ebxml_request_envelope.MESSAGE: sentinel.message
         }
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
-        mock_envelope.return_value.serialize.return_value = sentinel.ebxml_id, sentinel.ebxml_message
+        mock_envelope.return_value.serialize.return_value = \
+            sentinel.ebxml_id, sentinel.http_headers, sentinel.ebxml_message
 
         is_async, actual_id, actual_response = self.workflow.prepare_message(sentinel.interaction_name,
                                                                              sentinel.message)
@@ -56,7 +57,8 @@ class TestSyncAsyncWorkflow(TestCase):
         }
         interaction_details = {sync_async.ASYNC_RESPONSE_EXPECTED: True}
         self.mock_interactions_config.get_interaction_details.return_value = interaction_details
-        mock_envelope.return_value.serialize.return_value = sentinel.ebxml_id, sentinel.ebxml_message
+        mock_envelope.return_value.serialize.return_value = \
+            sentinel.ebxml_id, sentinel.http_headers, sentinel.ebxml_message
 
         is_async, actual_id, actual_response = self.workflow.prepare_message(sentinel.interaction_name,
                                                                              sentinel.message,

--- a/mhs/mhs/inbound/request/handler.py
+++ b/mhs/mhs/inbound/request/handler.py
@@ -28,7 +28,7 @@ class InboundHandler(tornado.web.RequestHandler):
 
         request_message = ebxml_request_envelope.EbxmlRequestEnvelope.from_string(self.request.headers,
                                                                                   self.request.body.decode())
-        ref_to_id = request_message.message_dictionary[ebxml_envelope.REF_TO_MESSAGE_ID]
+        ref_to_id = request_message.message_dictionary[ebxml_envelope.RECEIVED_MESSAGE_ID]
         logging.debug("Message received is in reference to '%s'", ref_to_id)
 
         if ref_to_id in self.callbacks:
@@ -48,7 +48,7 @@ class InboundHandler(tornado.web.RequestHandler):
             ebxml_envelope.CPA_ID: message_details[ebxml_envelope.CPA_ID],
             ebxml_envelope.CONVERSATION_ID: message_details[ebxml_envelope.CONVERSATION_ID],
             ebxml_ack_envelope.RECEIVED_MESSAGE_TIMESTAMP: message_details[ebxml_envelope.TIMESTAMP],
-            ebxml_ack_envelope.RECEIVED_MESSAGE_ID: message_details[ebxml_envelope.MESSAGE_ID]
+            ebxml_envelope.RECEIVED_MESSAGE_ID: message_details[ebxml_envelope.MESSAGE_ID]
         }
 
         ack_message = ebxml_ack_envelope.EbxmlAckEnvelope(ack_context)

--- a/mhs/mhs/inbound/request/handler.py
+++ b/mhs/mhs/inbound/request/handler.py
@@ -52,7 +52,7 @@ class InboundHandler(tornado.web.RequestHandler):
         }
 
         ack_message = ebxml_ack_envelope.EbxmlAckEnvelope(ack_context)
-        _, serialized_message = ack_message.serialize()
+        _, _, serialized_message = ack_message.serialize()
 
         self.set_header("Content-Type", "text/xml")
         self.write(serialized_message)


### PR DESCRIPTION
- Separate better the parsing code that is specific to request/responses and acks
- Refactor code a little
- Set flags to False when elements don't exist, instead of not setting them
- Error when mandatory stuff isn't found during parsing
- Add more tests
- Chain an exception that was added in #42.
- Use [`defusedxml`](https://pypi.org/project/defusedxml/) to add some level of protection against parsing of malformed xml
  - Potentially we don't actually need this, if we accept Spine as a trusted source of xml, but this feels a bit iffy to me, I feel like we should try and make the MHS protected.
- [x] Decide on headers, whether it makes sense to do them in this task or not
- [x] Go through MIME code
- [x] Check code coverage, see if more tests are required
- [x] Type hints