### PR TITLE
Convert to strings when logging

### DIFF
--- a/common/builder/pystache_message_builder.py
+++ b/common/builder/pystache_message_builder.py
@@ -30,7 +30,7 @@ class PystacheMessageBuilder:
             return self._renderer.render(self._parsed_template, message_dictionary)
         except pystache_context.KeyNotFoundError as e:
             logger.error('0001', 'Failed to find {Key} when generating message from {TemplateFile} . {ErrorMessage}',
-                         {'Key': e.key, 'TemplateFile': self.template_file, 'ErrorMessage': str(e)})
+                         {'Key': e.key, 'TemplateFile': self.template_file, 'ErrorMessage': e})
             raise MessageGenerationError(f'Failed to find key:{e.key} when generating message from'
                                          f' template file:{self.template_file}')
 

--- a/common/utilities/integration_adaptors_logger.py
+++ b/common/utilities/integration_adaptors_logger.py
@@ -88,6 +88,7 @@ class IntegrationAdaptorsLogger:
         """
         new_map = {}
         for key, value in dict_values.items():
+            value = str(value)
             if ' ' in value:
                 value = f'"{value}"'
 

--- a/common/utilities/tests/test_logger.py
+++ b/common/utilities/tests/test_logger.py
@@ -27,6 +27,17 @@ class TestLogger(TestCase):
         output = log.IntegrationAdaptorsLogger('SYS')._format_values_in_map(input_dict)
         self.assertEqual(output, expected_output)
 
+    def test_dictionary_with_non_string_values(self):
+        input_dict = {
+            'EasyKey': False
+        }
+
+        expected_output = {
+            'EasyKey': 'EasyKey=False'
+        }
+        output = log.IntegrationAdaptorsLogger('SYS')._format_values_in_map(input_dict)
+        self.assertEqual(output, expected_output)
+
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_custom_audit_level(self, mock_stdout):
         log.configure_logging()


### PR DESCRIPTION
Convert values to strings when logging, so we don't have to do this in our log statements.