### PR TITLE
RT-151 fix outbound workflow

### DIFF
--- a/mhs/common/mhs_common/state/tests/test_work_description.py
+++ b/mhs/common/mhs_common/state/tests/test_work_description.py
@@ -1,5 +1,4 @@
 import copy
-import json
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -55,7 +54,7 @@ class TestWorkDescription(unittest.TestCase):
         work_description = wd.WorkDescription(persistence, input_data)
 
         await work_description.publish()
-        persistence.add.assert_called_with(input_data[wd.DATA_KEY], json.dumps(input_data))
+        persistence.add.assert_called_with(input_data[wd.DATA_KEY], input_data)
 
     @patch('utilities.timing.get_time')
     @async_test
@@ -69,7 +68,7 @@ class TestWorkDescription(unittest.TestCase):
         work_description = wd.WorkDescription(persistence, input_data)
 
         await work_description.publish()
-        persistence.add.assert_called_with(input_data[wd.DATA_KEY], json.dumps(input_data))
+        persistence.add.assert_called_with(input_data[wd.DATA_KEY], input_data)
 
     @async_test
     async def test_out_of_date_version(self):
@@ -114,7 +113,7 @@ class TestWorkDescription(unittest.TestCase):
 
         # Check local version updated
         self.assertEqual(work_description.version, 2)
-        persistence.add.assert_called_with('aaa-aaa-aaa', json.dumps(updated))
+        persistence.add.assert_called_with('aaa-aaa-aaa', updated)
 
     @patch('utilities.timing.get_time')
     @async_test
@@ -131,7 +130,7 @@ class TestWorkDescription(unittest.TestCase):
         new_data[wd.DATA][wd.STATUS] = wd.MessageStatus.OUTBOUND_MESSAGE_ACKD
 
         await work_description.set_status(wd.MessageStatus.OUTBOUND_MESSAGE_ACKD)
-        persistence.add.assert_called_with(input_data[wd.DATA_KEY], json.dumps(new_data))
+        persistence.add.assert_called_with(input_data[wd.DATA_KEY], new_data)
 
     def test_null_persistence(self):
         with self.assertRaises(ValueError):

--- a/mhs/common/mhs_common/state/work_description.py
+++ b/mhs/common/mhs_common/state/work_description.py
@@ -163,10 +163,10 @@ class WorkDescription:
 
     def _serialise_data(self):
         """
-        A simple serialization method that produces a json string from the local data which can be stored in the
+        A simple serialization method that produces an object from the local data which can be stored in the
         persistence store
         """
-        data = {
+        return {
             DATA_KEY: self.message_key,
             DATA: {
                 CREATED_TIMESTAMP: self.created_timestamp,
@@ -176,5 +176,3 @@ class WorkDescription:
                 WORKFLOW: self.workflow
             }
         }
-
-        return json.dumps(data)

--- a/mhs/common/mhs_common/workflow/asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/asynchronous_express.py
@@ -10,6 +10,7 @@ from mhs_common.messages import ebxml_request_envelope, ebxml_envelope
 from mhs_common.state import persistence_adaptor
 from mhs_common.workflow import common_asynchronous
 from mhs_common.state import work_description as wd
+from mhs_common import workflow
 
 logger = log.IntegrationAdaptorsLogger('ASYNC_EXPRESS_WORKFLOW')
 
@@ -28,7 +29,7 @@ class AsynchronousExpressWorkflow(common_asynchronous.CommonAsynchronousWorkflow
                                       payload: str) -> Tuple[int, str]:
         logger.info('0001', 'Entered async express workflow to handle outbound message')
         wdo = wd.create_new_work_description(self.persistence_store, message_id,
-                                                           wd.MessageStatus.OUTBOUND_MESSAGE_RECEIVED)
+                                                           wd.MessageStatus.OUTBOUND_MESSAGE_RECEIVED, workflow.ASYNC_EXPRESS)
         await wdo.publish()
 
         error, message = await self._serialize_outbound_message(message_id, correlation_id, interaction_details,

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
@@ -7,6 +7,7 @@ from utilities import test_utilities
 from utilities.test_utilities import async_test
 
 import mhs_common.workflow.asynchronous_express as async_express
+from mhs_common import workflow
 from mhs_common.messages import ebxml_request_envelope, ebxml_envelope
 from mhs_common.state import work_description
 from mhs_common.state.work_description import MessageStatus
@@ -57,7 +58,8 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
         self.assertEqual(202, status)
         self.assertEqual('', message)
         self.mock_create_new_work_description.assert_called_once_with(self.mock_persistence_store, MESSAGE_ID,
-                                                                      MessageStatus.OUTBOUND_MESSAGE_RECEIVED)
+                                                                      MessageStatus.OUTBOUND_MESSAGE_RECEIVED,
+                                                                      workflow.ASYNC_EXPRESS)
         self.mock_work_description.publish.assert_called_once()
         self.assertEqual(
             [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED), mock.call(MessageStatus.OUTBOUND_MESSAGE_ACKD)],

--- a/mhs/outbound/outbound/transmission/outbound_transmission.py
+++ b/mhs/outbound/outbound/transmission/outbound_transmission.py
@@ -45,7 +45,7 @@ class OutboundTransmission(transmission_adaptor.TransmissionAdaptor):
         # Raise an error if a 4xx or 5xx HTTP status was returned.
         response.raise_for_status()
 
-        return response.content
+        return response
 
     @staticmethod
     def _build_headers(interaction_details):

--- a/mhs/outbound/outbound/transmission/tests/test_outbound_transmission.py
+++ b/mhs/outbound/outbound/transmission/tests/test_outbound_transmission.py
@@ -42,10 +42,6 @@ class TestOutboundTransmission(TestCase):
 
     @patch("requests.post")
     def test_make_request(self, mock_post):
-        mock_result = Mock()
-        mock_result.content = sentinel.content
-        mock_post.return_value = mock_result
-
         interaction_details = {
             URL_NAME: URL_VALUE,
             TYPE_NAME: TYPE_VALUE,
@@ -64,8 +60,8 @@ class TestOutboundTransmission(TestCase):
                                      cert=(CLIENT_CERT_PATH, CLIENT_KEY_PATH),
                                      verify=CLIENT_PEM_PATH
                                      )
-        mock_result.raise_for_status.assert_called()
-        self.assertIs(actual_response, sentinel.content, "Expected content should be returned.")
+        mock_post.return_value.raise_for_status.assert_called()
+        self.assertIs(actual_response, mock_post.return_value, "Expected content should be returned.")
 
     def test_build_headers(self):
         actual_headers = outbound_transmission.OutboundTransmission._build_headers({


### PR DESCRIPTION
This PR fixes 3 bugs:
- f03c83e Pass workflow type to a function, this bug was introduced in #57. A way of spotting this type of bug in the future would be to have integration tests (which we hopefully will soon) and to use something like http://mypy-lang.org/
- dce6d56 Return Requests Response object from outbound transmission component. This is a temporary fix that I should have done in #57. The outbound transmission component is being redone anyway, so this fix will go away pretty soon.
- 63b3816 Fix bug with double-deserialisation. Basically, `json.dumps` was getting called twice on the same data, so the first time the object would get turned into a string, and the second time it would get turned into a string-inside-a-string.