### PR TITLE
RT-156 Add env vars for setting inbound queue login details

### DIFF
--- a/common/comms/proton_queue_adaptor.py
+++ b/common/comms/proton_queue_adaptor.py
@@ -31,10 +31,14 @@ class ProtonQueueAdaptor(comms.queue_adaptor.QueueAdaptor):
         Construct a Proton implementation of a :class:`QueueAdaptor <comms.queue_adaptor.QueueAdaptor>`.
         The kwargs provided should contain the following information:
           * host: The host of the Message Queue to be interacted with.
+          * username: The username to use to connect to the Message Queue.
+          * password The password to user to connect to the Message Queue.
         :param kwargs: The key word arguments required for this constructor.
         """
         super().__init__()
         self.host = kwargs.get('host')
+        self.username = kwargs.get('username')
+        self.password = kwargs.get('password')
         logger.info('000', 'Initialized proton queue adaptor for {host}', {'host': self.host})
 
     async def send_async(self, message: str, properties: Dict[str, Any] = None) -> None:
@@ -66,27 +70,32 @@ class ProtonQueueAdaptor(comms.queue_adaptor.QueueAdaptor):
         Performs a synchronous send of a message, to the host defined when this adaptor was constructed.
         :param message: The message to be sent.
         """
-        proton.reactor.Container(ProtonMessagingHandler(self.host, message)).run()
+        proton.reactor.Container(ProtonMessagingHandler(self.host, self.username, self.password, message)).run()
 
 
 class ProtonMessagingHandler(proton.handlers.MessagingHandler):
     """Implementation of a Proton MessagingHandler which will send a single message."""
 
-    def __init__(self, host, message: proton.Message) -> None:
+    def __init__(self, host: str, username: str, password: str, message: proton.Message) -> None:
         """
         Constructs a MessagingHandler which will send a specified message to a specified host.
         :param host: The host to send the message to.
+        :param username: The username to login to the host with.
+        :param password: The password to login to the host with.
         :param message: The message to be sent to the host.
         """
         super().__init__()
         self._host = host
+        self._username = username
+        self._password = password
         self._message = message
         self._sender = None
         self._sent = False
 
     def on_start(self, event):
         logger.info('002', 'Establishing connection to {host} for sending messages.', {'host': self._host})
-        self._sender = event.container.create_sender(self._host)
+        self._sender = event.container.create_sender(proton.Url(self._host, username=self._username,
+                                                                password=self._password))
 
     def on_sendable(self, event):
         if event.sender.credit:

--- a/common/comms/proton_queue_adaptor.py
+++ b/common/comms/proton_queue_adaptor.py
@@ -32,7 +32,7 @@ class ProtonQueueAdaptor(comms.queue_adaptor.QueueAdaptor):
         The kwargs provided should contain the following information:
           * host: The host of the Message Queue to be interacted with.
           * username: The username to use to connect to the Message Queue.
-          * password The password to user to connect to the Message Queue.
+          * password The password to use to connect to the Message Queue.
         :param kwargs: The key word arguments required for this constructor.
         """
         super().__init__()

--- a/common/comms/tests/test_proton_queue_adaptor.py
+++ b/common/comms/tests/test_proton_queue_adaptor.py
@@ -1,6 +1,8 @@
 """Module for testing the Proton queue adaptor functionality."""
 import unittest.mock
 
+import proton
+
 import comms.proton_queue_adaptor
 import utilities.test_utilities
 
@@ -9,6 +11,8 @@ TEST_MESSAGE = "TEST MESSAGE"
 TEST_PROPERTIES = {'test-property-name': 'test-property-value'}
 TEST_PROTON_MESSAGE = unittest.mock.Mock()
 TEST_QUEUE_HOST = "TEST QUEUE HOST"
+TEST_QUEUE_USERNAME = "TEST QUEUE USERNAME"
+TEST_QUEUE_PASSWORD = "TEST QUEUE PASSWORD"
 TEST_EXCEPTION = Exception()
 TEST_SIDE_EFFECT = unittest.mock.Mock(side_effect=TEST_EXCEPTION)
 
@@ -22,7 +26,8 @@ class TestProtonQueueAdaptor(unittest.TestCase):
         patcher = unittest.mock.patch.object(comms.proton_queue_adaptor.proton.reactor, "Container")
         self.mock_container = patcher.start()
         self.addCleanup(patcher.stop)
-        self.service = comms.proton_queue_adaptor.ProtonQueueAdaptor(host=TEST_QUEUE_HOST)
+        self.service = comms.proton_queue_adaptor.ProtonQueueAdaptor(host=TEST_QUEUE_HOST, username=TEST_QUEUE_USERNAME,
+                                                                     password=TEST_QUEUE_PASSWORD)
 
     # TESTING SEND ASYNC METHOD
 
@@ -66,6 +71,8 @@ class TestProtonQueueAdaptor(unittest.TestCase):
         self.assertTrue(self.mock_container.return_value.run.called)
         proton_messaging_handler = self.mock_container.call_args[0][0]
         self.assertEqual(TEST_QUEUE_HOST, proton_messaging_handler._host)
+        self.assertEqual(TEST_QUEUE_USERNAME, proton_messaging_handler._username)
+        self.assertEqual(TEST_QUEUE_PASSWORD, proton_messaging_handler._password)
         self.assertEqual(TEST_MESSAGE, proton_messaging_handler._message.body)
         self.assertEqual(TEST_UUID, proton_messaging_handler._message.id)
         self.assertEqual(properties, proton_messaging_handler._message.properties)
@@ -76,7 +83,8 @@ class TestProtonMessagingHandler(unittest.TestCase):
 
     def setUp(self) -> None:
         """Prepare service for testing."""
-        self.handler = comms.proton_queue_adaptor.ProtonMessagingHandler(TEST_QUEUE_HOST, TEST_PROTON_MESSAGE)
+        self.handler = comms.proton_queue_adaptor.ProtonMessagingHandler(TEST_QUEUE_HOST, TEST_QUEUE_USERNAME,
+                                                                         TEST_QUEUE_PASSWORD, TEST_PROTON_MESSAGE)
 
     # TESTING STARTUP METHOD
     def test_on_start_success(self):
@@ -85,7 +93,9 @@ class TestProtonMessagingHandler(unittest.TestCase):
 
         self.handler.on_start(mock_event)
 
-        self.assertTrue(mock_event.container.create_sender.called)
+        mock_event.container.create_sender.assert_called_once_with(proton.Url(TEST_QUEUE_HOST,
+                                                                              username=TEST_QUEUE_USERNAME,
+                                                                              password=TEST_QUEUE_PASSWORD))
 
     def test_on_start_error(self):
         """Test error condition when creating a message sender."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       - MHS_LOG_LEVEL=NOTSET
       - MHS_INBOUND_QUEUE_HOST=rabbitmq:5672/inbound
+      - MHS_INBOUND_QUEUE_USERNAME=guest
+      - MHS_INBOUND_QUEUE_PASSWORD=guest
       - MHS_STATE_TABLE_NAME=mhs_state
       - MHS_DYNAMODB_ENDPOINT_URL=http://dynamodb:8000
       # boto3 requires some AWS creds to be provided, even

--- a/mhs/README.md
+++ b/mhs/README.md
@@ -39,6 +39,8 @@ MHS takes a number of environment variables when it is run. These are:
 * `MHS_STATE_TABLE_NAME` The name of the DynamoDB table used to store MHS state.
 * `MHS_OUTBOUND_TRANSMISSION_MAX_RETRIES` This is the maximum number of retries for outbound requests. If no value is given a default of 3 is used.
 * `MHS_INBOUND_QUEUE_HOST` (inbound only) The host url of the amqp inbound queue. e.g. `amqps://example.com:port/queue-name`. Note that if the amqp connection being used is a secured connection (which it should be in production), then the url should start with `amqps://` and not `amqp+ssl://`.
+* `MHS_INBOUND_QUEUE_USERNAME` (inbound only) The username to use when connecting to the amqp inbound queue.
+* `MHS_INBOUND_QUEUE_PASSWORD` (inbound only) The password to use when connecting to the amqp inbound queue.
 
 ## Running Unit Tests
 - `pipenv run unittests` will run all unit tests.

--- a/mhs/inbound/main.py
+++ b/mhs/inbound/main.py
@@ -24,7 +24,9 @@ def initialise_workflows() -> Dict[str, workflow.CommonWorkflow]:
     """Initialise the workflows
     :return: The workflows that can be used to handle messages.
     """
-    queue_adaptor = proton_queue_adaptor.ProtonQueueAdaptor(host=config.get_config('INBOUND_QUEUE_HOST'))
+    queue_adaptor = proton_queue_adaptor.ProtonQueueAdaptor(host=config.get_config('INBOUND_QUEUE_HOST'),
+                                                            username=config.get_config('INBOUND_QUEUE_USERNAME'),
+                                                            password=config.get_config('INBOUND_QUEUE_PASSWORD'))
 
     return workflow.get_workflow_map(queue_adaptor=queue_adaptor)
 

--- a/mhs/outbound/outbound/request/common.py
+++ b/mhs/outbound/outbound/request/common.py
@@ -1,6 +1,0 @@
-"""This module defines the mhs_common base of outbound request handlers."""
-
-
-class CommonOutbound:
-    """The mhs_common base class for all outbound request handlers."""
-    pass


### PR DESCRIPTION
- Add `MHS_INBOUND_QUEUE_USERNAME` and `MHS_INBOUND_QUEUE_PASSWORD` environment variables for setting the username and password
  - I've tested this locally with the async-express workflow and have checked the logs to see where the username/password gets logged. There was only one log line that included it: `inbound_1   | [2019-08-27T10:22:22.361533Z] connecting to Url('amqp://guest:guest@rabbitmq:5672/inbound')... pid=6 LogLevel=DEBUG`. That is a DEBUG log, so shouldn't be being logged in production, so I think this is working correctly.
- Remove the `CommonOutbound` file. I don't see any point in keeping this file, as we are currently expecting to only support a sync outbound request handler. If we need this file later, we can always add it again.