### PR TITLE
Include unit in timing log message

### DIFF
--- a/common/utilities/tests/test_timing.py
+++ b/common/utilities/tests/test_timing.py
@@ -26,11 +26,11 @@ class TestTimeUtilities(TestCase):
     def test_invoke_with_time_rounding(self, log_mock):
         with self.subTest("Default"):
             timing._log_time(5.1236, "yes")
-            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                              {'FuncName': 'yes', 'Duration': 5.124})
         with self.subTest("Tornado"):
             timing._log_tornado_time(5.1236, "yes", "methodName")
-            log_mock.info.assert_called_with('0002', '{FuncName} from {Handler} took {Duration}',
+            log_mock.info.assert_called_with('0002', '{FuncName} from {Handler} took {Duration} seconds',
                                              {'FuncName': 'methodName', 'Handler': 'yes', 'Duration': 5.124})
 
     @patch('utilities.timing._log_time')
@@ -71,13 +71,13 @@ class TestTimeUtilities(TestCase):
         with self.subTest("Sync"):
             time_mock.return_value = 5
             res = self.take_parameters("whew", 1, [2], {3: 3})
-            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                              {'FuncName': 'take_parameters', 'Duration': 5})
             self.assertEqual("whew1", res)
         with self.subTest("Async"):
             time_mock.return_value = 5
             res = await self.take_parameters_async("whew", 1, [2], {3: 3})
-            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                              {'FuncName': 'take_parameters_async', 'Duration': 5})
             self.assertEqual("whew1", res)
 
@@ -93,7 +93,7 @@ class TestTimeUtilities(TestCase):
 
         await task
 
-        log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+        log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                          {'FuncName': 'default_method_async', 'Duration': 2})
 
     @patch('utilities.timing.Stopwatch.stop_timer')
@@ -103,13 +103,13 @@ class TestTimeUtilities(TestCase):
         with self.subTest("Sync"):
             time_mock.return_value = 5
             res = self.var_parameters("whew", 1, 2, 3, 4, 5)
-            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                              {'FuncName': 'var_parameters', 'Duration': 5})
             self.assertEqual("whew12345", res)
         with self.subTest("Async"):
             time_mock.return_value = 5
             res = await self.var_parameters_async("whew", 1, "three", 4)
-            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration}',
+            log_mock.info.assert_called_with('0001', '{FuncName} took {Duration} seconds',
                                              {'FuncName': 'var_parameters_async', 'Duration': 5})
             self.assertEqual("whew1three4", res)
 
@@ -188,7 +188,7 @@ class TestHTTPWrapperTimeUtilities(AsyncHTTPTestCase):
         self.assertEqual(response.code, expected_code)
         if expected_body:
             self.assertEqual(response.body.decode('utf8'), expected_body)
-        log_mock.info.assert_called_with('0002', '{FuncName} from {Handler} took {Duration}',
+        log_mock.info.assert_called_with('0002', '{FuncName} from {Handler} took {Duration} seconds',
                                          {'FuncName': expected_func_name, 'Handler': 'FakeRequestHandler',
                                           'Duration': self.duration})
 

--- a/common/utilities/timing.py
+++ b/common/utilities/timing.py
@@ -29,12 +29,12 @@ def _begin_stopwatch():
 
 def _log_time(duration, func_name):
     duration = round(duration, 3)
-    logger.info('0001', '{FuncName} took {Duration}', {'FuncName': func_name, 'Duration': duration})
+    logger.info('0001', '{FuncName} took {Duration} seconds', {'FuncName': func_name, 'Duration': duration})
 
 
 def _log_tornado_time(duration, handler, func_name):
     duration = round(duration, 3)
-    logger.info('0002', '{FuncName} from {Handler} took {Duration}',
+    logger.info('0002', '{FuncName} from {Handler} took {Duration} seconds',
                 {'FuncName': func_name, 'Handler': handler, 'Duration': duration})
 
 


### PR DESCRIPTION
Say in the log messages that the times are in seconds when timing functions/methods.