### PR TITLE
Improve Packer CI output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,10 @@ pipeline {
 
         stage('Package') {
             steps {
-                sh label: 'Running Inbound Packer build', script: 'packer build pipeline/packer/inbound.json'
-                sh label: 'Running Outbound Packer build', script: 'packer build pipeline/packer/outbound.json'
-                sh label: 'Running Spine Route Lookup Packer build', script: 'packer build pipeline/packer/spineroutelookup.json'
-                sh label: 'Running SCR service Packer build', script: 'packer build pipeline/packer/scr-web-service.json'
+                sh label: 'Running Inbound Packer build', script: 'packer build -color=false pipeline/packer/inbound.json'
+                sh label: 'Running Outbound Packer build', script: 'packer build -color=false pipeline/packer/outbound.json'
+                sh label: 'Running Spine Route Lookup Packer build', script: 'packer build -color=false pipeline/packer/spineroutelookup.json'
+                sh label: 'Running SCR service Packer build', script: 'packer build -color=false pipeline/packer/scr-web-service.json'
             }
         }
 


### PR DESCRIPTION
This should stop the ANSI colour escape codes appearing in Jenkins output. Note that I have already made the corresponding change for Terraform in #77.