### PR TITLE
* fix for bug that sets the inbound status incorrectly

### DIFF
--- a/integration-tests/integration_tests/test_scenarios/int_sync_test.py
+++ b/integration-tests/integration_tests/test_scenarios/int_sync_test.py
@@ -28,7 +28,7 @@ class SynchronousWorkflowTests(TestCase):
         DynamoMhsTableStateAssertor(MHS_DYNAMO_WRAPPER.get_all_records_in_table()) \
             .assert_single_item_exists_with_key(message_id) \
             .assert_item_contains_values({
-                # 'INBOUND_STATUS': None,
+                'INBOUND_STATUS': None,
                 'OUTBOUND_STATUS': 'SYNC_RESPONSE_SUCCESSFUL',
                 'WORKFLOW': 'sync'
             })

--- a/mhs/common/mhs_common/workflow/synchronous.py
+++ b/mhs/common/mhs_common/workflow/synchronous.py
@@ -43,8 +43,7 @@ class SynchronousWorkflow(common_synchronous.CommonSynchronousWorkflow):
         wdo = wd.create_new_work_description(self.wd_store,
                                              message_id,
                                              workflow.SYNC,
-                                             wd.MessageStatus.OUTBOUND_MESSAGE_RECEIVED
-                                             )
+                                             outbound_status=wd.MessageStatus.OUTBOUND_MESSAGE_RECEIVED)
         await wdo.publish()
         if not from_asid:
             return 400, '`from_asid` header field required for sync messages', None

--- a/mhs/common/mhs_common/workflow/tests/test_synchronous.py
+++ b/mhs/common/mhs_common/workflow/tests/test_synchronous.py
@@ -34,7 +34,7 @@ class TestSynchronousWorkflow(unittest.TestCase):
 
     @mock.patch('mhs_common.state.work_description.create_new_work_description')
     @async_test
-    async def test_store_status_set_to_received(self, wd_mock):
+    async def test_should_set_store_outbound_status_to_received_when_handling_outbound_message(self, wd_mock):
         wdo_mock = mock.MagicMock()
         wd_mock.return_value = wdo_mock
 
@@ -47,8 +47,7 @@ class TestSynchronousWorkflow(unittest.TestCase):
             # Don't care for exceptions, just want to check the store is set correctly first
             pass
 
-        wd_mock.assert_called_with(self.wd_store, "123", workflow.SYNC,
-                                   work_description.MessageStatus.OUTBOUND_MESSAGE_RECEIVED)
+        wd_mock.assert_called_with(self.wd_store, "123", workflow.SYNC, outbound_status=work_description.MessageStatus.OUTBOUND_MESSAGE_RECEIVED)
         wdo_mock.publish.assert_called_once()
 
     @mock.patch.object(sync, 'logger')


### PR DESCRIPTION
Bug: 
- when a synchronous workflow is initalised it sets the inbound status incorrectly, it should have set the outbound status and left the inbound status null (as there is no inbound workflow).