### PR TITLE
Remove only Docker images for the current CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ pipeline {
         always {
             cobertura coberturaReportFile: '**/coverage.xml'
             junit '**/test-reports/*.xml'
-            sh 'docker images rm $(docker images "*/*/*:${BUILD_TAG}" -q)'
+            sh 'docker images rm $(docker images "*/*:${BUILD_TAG}" -q) $(docker images "*/*/*:${BUILD_TAG}" -q)'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,6 +214,8 @@ pipeline {
         always {
             cobertura coberturaReportFile: '**/coverage.xml'
             junit '**/test-reports/*.xml'
+            // Prune Docker images for current CI build.
+            // Note that the * in the glob patterns doesn't match /
             sh 'docker images rm $(docker images "*/*:${BUILD_TAG}" -q) $(docker images "*/*/*:${BUILD_TAG}" -q)'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
             junit '**/test-reports/*.xml'
             // Prune Docker images for current CI build.
             // Note that the * in the glob patterns doesn't match /
-            sh 'docker images rm $(docker images "*/*:${BUILD_TAG}" -q) $(docker images "*/*/*:${BUILD_TAG}" -q)'
+            sh 'docker image rm $(docker images "*/*:${BUILD_TAG}" -q) $(docker images "*/*/*:${BUILD_TAG}" -q)'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
             junit '**/test-reports/*.xml'
             // Prune Docker images for current CI build.
             // Note that the * in the glob patterns doesn't match /
-            sh 'docker image rm $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q) || true'
+            sh 'docker image rm -f $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q) || true'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ pipeline {
         always {
             cobertura coberturaReportFile: '**/coverage.xml'
             junit '**/test-reports/*.xml'
-            sh 'docker image prune -a --force'
+            sh 'docker images rm $(docker images "*/*/*:${BUILD_TAG}" -q)'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
             junit '**/test-reports/*.xml'
             // Prune Docker images for current CI build.
             // Note that the * in the glob patterns doesn't match /
-            sh 'docker image rm $(docker images "*/*:${BUILD_TAG}" -q) $(docker images "*/*/*:${BUILD_TAG}" -q)'
+            sh 'docker image rm $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q)'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,7 +216,7 @@ pipeline {
             junit '**/test-reports/*.xml'
             // Prune Docker images for current CI build.
             // Note that the * in the glob patterns doesn't match /
-            sh 'docker image rm $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q)'
+            sh 'docker image rm $(docker images "*/*:*${BUILD_TAG}" -q) $(docker images "*/*/*:*${BUILD_TAG}" -q) || true'
         }
     }
 }


### PR DESCRIPTION
`docker images` is used to search for images with a particular tag. I've had to hack this a bit as it doesn't properly support doing this. `docker image rm` is used to remove (prune) those images.

I'm hoping that this will allow us to run Jenkins builds at the same time again.