### PR TITLE
Rt 264/async-express-sync-async-wrap-faults

### DIFF
--- a/integration-tests/integration_tests/integration_tests/component_tests/component_asynchronous_express_message_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/component_tests/component_asynchronous_express_message_pattern_tests.py
@@ -9,7 +9,7 @@ from integration_tests.helpers.build_message import build_message
 from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
 
 
-class SynchronousMessagingPatternTests(unittest.TestCase):
+class AsynchronousExpressMssagingPatternTests(unittest.TestCase):
     """
     These tests show an asynchronous express response from Spine via the MHS for the example message interaction
     of PSIS(Personal Spine Information Service).
@@ -72,7 +72,7 @@ class SynchronousMessagingPatternTests(unittest.TestCase):
     def test_should_return_information_from_ebxml_fault_returned_from_spine_in_original_post_request(self):
         """
         Message ID: '7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA' configured in fakespine to return a ebxml Fault error.
-        Error found here: fake_spine/fake_spine/configured_responses/soap_fault_single_error.xml
+        Error found here: fake_spine/fake_spine/configured_responses/ebxml_fault_single_error.xml
         """
         # Arrange
         message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
@@ -90,11 +90,10 @@ class SynchronousMessagingPatternTests(unittest.TestCase):
             .assert_severity('Error') \
             .assert_error_type('ebxml_error')
 
-
     def test_should_record_message_status_as_nackd_when_ebxml_error_response_returned_from_spine(self):
         """
         Message ID: '7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA' configured in fakespine to return a ebxml Fault error.
-        Error found here: fake_spine/fake_spine/configured_responses/soap_fault_single_error.xml
+        Error found here: fake_spine/fake_spine/configured_responses/ebxml_fault_single_error.xml
         """
         # Arrange
         message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
@@ -116,3 +115,94 @@ class SynchronousMessagingPatternTests(unittest.TestCase):
                 'WORKFLOW': 'async-express'
             })
 
+    def test_should_return_information_from_soap_fault_returned_from_spine_in_original_request_to_client_when_sync_async_requested(self):
+        """
+        Message ID: AD7D39A8-1B6C-4520-8367-6B7BEBD7B842 configured in fakespine to return a SOAP Fault error.
+        Error found here: fake_spine/fake_spine/configured_responses/soap_fault_single_error.xml
+        """
+        # Arrange
+        message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
+                                            message_id='AD7D39A8-1B6C-4520-8367-6B7BEBD7B842'
+                                            )
+        # Act
+        response = MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='QUPC_IN160101UK05', message_id=message_id, sync_async=True) \
+            .with_body(message) \
+            .execute_post_expecting_error_response()
+
+        # Assert
+        TextErrorResponseAssertor(response.text) \
+            .assert_error_code(200) \
+            .assert_code_context('urn:nhs:names:error:tms') \
+            .assert_severity('Error')
+
+    def test_should_record_message_status_as_nackd_when_soap_error_response_returned_from_spine_and_sync_async_requested(self):
+        """
+        Message ID: AD7D39A8-1B6C-4520-8367-6B7BEBD7B842 configured in fakespine to return a SOAP Fault error.
+        Error found here: fake_spine/fake_spine/configured_responses/soap_fault_single_error.xml
+        """
+        # Arrange
+        message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
+                                            message_id='AD7D39A8-1B6C-4520-8367-6B7BEBD7B842'
+                                            )
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='QUPC_IN160101UK05', message_id=message_id, sync_async=True) \
+            .with_body(message) \
+            .execute_post_expecting_error_response()
+
+        # Assert
+        DynamoMhsTableStateAssertor(MHS_STATE_TABLE_DYNAMO_WRAPPER.get_all_records_in_table()) \
+            .assert_single_item_exists_with_key(message_id) \
+            .assert_item_contains_values(
+            {
+                'INBOUND_STATUS': None,
+                'OUTBOUND_STATUS': 'OUTBOUND_SYNC_ASYNC_MESSAGE_SUCCESSFULLY_RESPONDED',
+                'WORKFLOW': 'sync-async'
+            })
+
+    def test_should_return_information_in_ebxml_fault_returned_from_spine_in_original_post_request_to_client_when_sync_async_requested(self):
+        """
+        Message ID: '7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA' configured in fakespine to return a ebxml Fault error.
+        Error found here: fake_spine/fake_spine/configured_responses/ebxml_fault_single_error.xml
+        """
+        # Arrange
+        message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
+                                            message_id='7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA'
+                                            )
+        # Act
+        response = MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='QUPC_IN160101UK05', message_id=message_id, sync_async=True) \
+            .with_body(message) \
+            .execute_post_expecting_error_response()
+
+        # Assert
+        TextErrorResponseAssertor(response.text) \
+            .assert_code_context('urn:oasis:names:tc:ebxml') \
+            .assert_severity('Error') \
+            .assert_error_type('ebxml_error')
+
+    def test_should_record_message_status_when_ebxml_error_response_returned_from_spine_and_sync_async_requested(self):
+        """
+        Message ID: '7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA' configured in fakespine to return a ebxml Fault error.
+        Error found here: fake_spine/fake_spine/configured_responses/ebxml_fault_single_error.xml
+        """
+        # Arrange
+        message, message_id = build_message('QUPC_IN160101UK05', '9689177923',
+                                            message_id='7AA57E38-8B20-4AE0-9E73-B9B0C0C42BDA'
+                                            )
+        # Act
+        MhsHttpRequestBuilder() \
+            .with_headers(interaction_id='QUPC_IN160101UK05', message_id=message_id, sync_async=True) \
+            .with_body(message) \
+            .execute_post_expecting_error_response()
+
+        # Assert
+        DynamoMhsTableStateAssertor(MHS_STATE_TABLE_DYNAMO_WRAPPER.get_all_records_in_table()) \
+            .assert_single_item_exists_with_key(message_id) \
+            .assert_item_contains_values(
+            {
+                'INBOUND_STATUS': None,
+                'OUTBOUND_STATUS': 'OUTBOUND_SYNC_ASYNC_MESSAGE_SUCCESSFULLY_RESPONDED',
+                'WORKFLOW': 'sync-async'
+            })

--- a/integration-tests/integration_tests/integration_tests/component_tests/component_asynchronous_express_message_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/component_tests/component_asynchronous_express_message_pattern_tests.py
@@ -136,7 +136,7 @@ class AsynchronousExpressMssagingPatternTests(unittest.TestCase):
             .assert_code_context('urn:nhs:names:error:tms') \
             .assert_severity('Error')
 
-    def test_should_record_message_status_as_nackd_when_soap_error_response_returned_from_spine_and_sync_async_requested(self):
+    def test_should_record_message_status_when_soap_error_response_returned_from_spine_and_sync_async_requested(self):
         """
         Message ID: AD7D39A8-1B6C-4520-8367-6B7BEBD7B842 configured in fakespine to return a SOAP Fault error.
         Error found here: fake_spine/fake_spine/configured_responses/soap_fault_single_error.xml


### PR DESCRIPTION
Contains 264 & 265, soap fault and ebxml fault handling component tests for the sync-async wrap of the async-express workflow