### PR TITLE
Feature/rt 212 renable tls for outbound

### DIFF
--- a/mhs/README.md
+++ b/mhs/README.md
@@ -3,11 +3,6 @@
 This package contains a pre-assured implementation of a Message Handling Service (MHS), intended to encapsulate the
 details of Spine messaging and provide a simple interface to allow HL7 messages to be sent to a remote MHS.
 
-**WARNING: Verification of the server certificate received when making a connection to a remote MHS is currently
-DISABLED (see the [OutboundTransmission](./outbound/outbound/transmission/outbound_transmission.py) class'
-`make_request` method).** This MHS should not be used in a production environment unless this certificate verification
-is re-enabled.
-
 ## Setup
 You'll need to have a connection to Spine. For testing purposes, you can use [Opentest](https://nhs-digital-opentest.github.io/Welcome/index.html).
 

--- a/mhs/outbound/outbound/transmission/outbound_transmission.py
+++ b/mhs/outbound/outbound/transmission/outbound_transmission.py
@@ -52,14 +52,9 @@ class OutboundTransmission(transmission_adaptor.TransmissionAdaptor):
             logger.info("0001", "About to send message with {headers} to {url} using {proxy_host} & {proxy_port}",
                         {"headers": headers, "url": url, "proxy_host": self._proxy_host,
                          "proxy_port": self._proxy_port})
-            # ******************************************************************************************************
-            # TLS CERTIFICATE VALIDATION HAS BEEN TEMPORARILY DISABLED! This is required because Opentest's SDS
-            # instance currently returns endpoints as IP addresses. This MUST be changed before this code is used in
-            # a production environment
-            # ******************************************************************************************************
             response = await CommonHttps.make_request(url=url, method="POST", headers=headers, body=message,
                                                       client_cert=self._client_cert, client_key=self._client_key,
-                                                      ca_certs=self._ca_certs, validate_cert=False,
+                                                      ca_certs=self._ca_certs, validate_cert=True,
                                                       http_proxy_host=self._proxy_host,
                                                       http_proxy_port=self._proxy_port,
                                                       raise_error_response=raise_error_response)

--- a/mhs/outbound/outbound/transmission/tests/test_outbound_transmission.py
+++ b/mhs/outbound/outbound/transmission/tests/test_outbound_transmission.py
@@ -64,11 +64,7 @@ class TestOutboundTransmission(TestCase):
                                           client_cert=CLIENT_CERT_PATH,
                                           client_key=CLIENT_KEY_PATH,
                                           ca_certs=CA_CERTS_PATH,
-                                          # ****************************************************************************
-                                          # This SHOULD be true, but we must temporarily set it to false due to Opentest
-                                          # limitations.
-                                          # ****************************************************************************
-                                          validate_cert=False,
+                                          validate_cert=True,
                                           proxy_host=None,
                                           proxy_port=None
                                           )
@@ -95,11 +91,7 @@ class TestOutboundTransmission(TestCase):
                                           client_cert=CLIENT_CERT_PATH,
                                           client_key=CLIENT_KEY_PATH,
                                           ca_certs=CA_CERTS_PATH,
-                                          # ****************************************************************************
-                                          # This SHOULD be true, but we must temporarily set it to false due to Opentest
-                                          # limitations.
-                                          # ****************************************************************************
-                                          validate_cert=False,
+                                          validate_cert=True,
                                           proxy_host=HTTP_PROXY_HOST,
                                           proxy_port=HTTP_PROXY_PORT)
 


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------------------
DO NOT CHECK-IN TO DEVELOP AS THE CHANGES HAVE NOT BEEN MADE BY THE OPEN TEST TEAM
----------------------------------------------------------------------------------------------------------------

- Re-enabled TLS cert validation by setting `validateCert` to `True` in `outbound_transmission.py`
- Updated relevant tests
- Updated the `README.md` to remove the WARNING about TLS cert validation been disabled
