### PR TITLE
Fix work description statuses

### DIFF
--- a/mhs/common/mhs_common/workflow/asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/asynchronous_express.py
@@ -63,14 +63,13 @@ class AsynchronousExpressWorkflow(common_asynchronous.CommonAsynchronousWorkflow
             to_party_key = details[self.ENDPOINT_PARTY_KEY]
             cpa_id = details[self.ENDPOINT_CPA_ID]
         except Exception:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error obtaining outbound URL', None
 
         error, http_headers, message = await self._serialize_outbound_message(message_id, correlation_id,
                                                                               interaction_details,
                                                                               payload, wdo, to_party_key, cpa_id)
         if error:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
             return error[0], error[1], None
 
         return await self._make_outbound_request_and_handle_response(url, http_headers, message, wdo,

--- a/mhs/common/mhs_common/workflow/asynchronous_forward_reliable.py
+++ b/mhs/common/mhs_common/workflow/asynchronous_forward_reliable.py
@@ -60,15 +60,8 @@ class AsynchronousForwardReliableWorkflow(asynchronous_reliable.AsynchronousReli
             to_party_key = details[self.ENDPOINT_PARTY_KEY]
             cpa_id = details[self.ENDPOINT_CPA_ID]
         except Exception:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error obtaining outbound URL', None
-
-        error, http_headers, message = await self._serialize_outbound_message(message_id, correlation_id,
-                                                                              interaction_details,
-                                                                              payload, wdo, to_party_key, cpa_id)
-        if error:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
-            return error[0], error[1], None
 
         reliability_details = await self._lookup_reliability_details(interaction_details,
                                                                      interaction_details.get('ods-code'))
@@ -76,8 +69,14 @@ class AsynchronousForwardReliableWorkflow(asynchronous_reliable.AsynchronousReli
         try:
             retry_interval = DateUtilities.convert_xml_date_time_format_to_seconds(retry_interval_xml_datetime)
         except isoerror.ISO8601Error:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error when converting retry interval: {} to seconds'.format(retry_interval_xml_datetime), None
+
+        error, http_headers, message = await self._serialize_outbound_message(message_id, correlation_id,
+                                                                              interaction_details,
+                                                                              payload, wdo, to_party_key, cpa_id)
+        if error:
+            return error[0], error[1], None
 
         return await self._make_outbound_request_with_retries_and_handle_response(url, http_headers, message, wdo,
                                                                                   reliability_details, retry_interval)

--- a/mhs/common/mhs_common/workflow/asynchronous_reliable.py
+++ b/mhs/common/mhs_common/workflow/asynchronous_reliable.py
@@ -64,23 +64,22 @@ class AsynchronousReliableWorkflow(common_asynchronous.CommonAsynchronousWorkflo
             to_party_key = details[self.ENDPOINT_PARTY_KEY]
             cpa_id = details[self.ENDPOINT_CPA_ID]
         except Exception:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error obtaining outbound URL', None
-
-        error, http_headers, message = await self._serialize_outbound_message(message_id, correlation_id,
-                                                                              interaction_details,
-                                                                              payload, wdo, to_party_key, cpa_id)
-        if error:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
-            return error[0], error[1], None
 
         reliability_details = await self._lookup_reliability_details(interaction_details)
         retry_interval_xml_datetime = reliability_details[common_asynchronous.MHS_RETRY_INTERVAL]
         try:
             retry_interval = DateUtilities.convert_xml_date_time_format_to_seconds(retry_interval_xml_datetime)
         except isoerror.ISO8601Error:
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error when converting retry interval: {} to seconds'.format(retry_interval_xml_datetime), None
+
+        error, http_headers, message = await self._serialize_outbound_message(message_id, correlation_id,
+                                                                              interaction_details,
+                                                                              payload, wdo, to_party_key, cpa_id)
+        if error:
+            return error[0], error[1], None
 
         return await self._make_outbound_request_with_retries_and_handle_response(url, http_headers, message, wdo,
                                                                                   reliability_details, retry_interval)

--- a/mhs/common/mhs_common/workflow/common_asynchronous.py
+++ b/mhs/common/mhs_common/workflow/common_asynchronous.py
@@ -89,7 +89,12 @@ class CommonAsynchronousWorkflow(CommonWorkflow):
             handle_error_response: Callable[[httpclient.HTTPResponse], Tuple[int, str, Optional[wd.WorkDescription]]]):
 
         logger.info('0006', 'About to make outbound request')
-        response = await self.transmission.make_request(url, http_headers, message, raise_error_response=False)
+        try:
+            response = await self.transmission.make_request(url, http_headers, message, raise_error_response=False)
+        except Exception as e:
+            logger.error('0008', 'Error encountered whilst making outbound request. {Exception}', {'Exception': e})
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            return 500, 'Error making outbound request', None
 
         if response.code == 202:
             logger.audit('0101', '{WorkflowName} outbound workflow invoked. Message sent to Spine and {Acknowledgment} '

--- a/mhs/common/mhs_common/workflow/synchronous.py
+++ b/mhs/common/mhs_common/workflow/synchronous.py
@@ -91,7 +91,7 @@ class SynchronousWorkflow(common_synchronous.CommonSynchronousWorkflow):
             return code, error, wdo
 
         except Exception as e:
-            logger.warning('0006', 'Error encountered whilst making outbound request. {Exception}', {'Exception': e})
+            logger.error('0006', 'Error encountered whilst making outbound request. {Exception}', {'Exception': e})
             await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
             return 500, 'Error making outbound request', None
 

--- a/mhs/common/mhs_common/workflow/synchronous.py
+++ b/mhs/common/mhs_common/workflow/synchronous.py
@@ -59,7 +59,7 @@ class SynchronousWorkflow(common_synchronous.CommonSynchronousWorkflow):
             to_asid = endpoint_details[self.ENDPOINT_TO_ASID]
         except Exception:
             logger.error('009', 'Failed to retrieve details from spine route lookup')
-            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+            await wdo.set_outbound_status(wd.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
             return 500, 'Error obtaining outbound URL', None
 
         try:

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
@@ -190,8 +190,7 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error serialising outbound message', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -209,8 +208,7 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
 
         self.assertEqual(400, status)
         self.assertIn('Request to send to Spine is too large', message)
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -226,7 +224,7 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error obtaining outbound URL', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -229,6 +230,29 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
         self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
+
+    @async_test
+    async def test_non_http_error_handled_when_making_request_to_spine(self):
+        self.setup_mock_work_description()
+        self._setup_routing_mock()
+
+        self.mock_ebxml_request_envelope.return_value.serialize.return_value = (MESSAGE_ID, {}, SERIALIZED_MESSAGE)
+
+        error_future = asyncio.Future()
+        error_future.set_exception(ssl.SSLError())
+        self.mock_transmission_adaptor.make_request.return_value = error_future
+
+        status, message, _ = await self.workflow.handle_outbound_message(None, MESSAGE_ID, CORRELATION_ID,
+                                                                         INTERACTION_DETAILS,
+                                                                         PAYLOAD, None)
+
+        self.assertEqual(500, status)
+        self.assertEqual("Error making outbound request", message)
+        self.mock_work_description.publish.assert_called_once()
+        self.assertEqual(
+            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED),
+             mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+            self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')
     @async_test

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_express.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import exceptions
 from comms import proton_queue_adaptor
-from tornado import httpclient
 from utilities import test_utilities
 from utilities.file_utilities import FileUtilities
 from utilities.test_utilities import async_test
@@ -264,7 +263,7 @@ class TestAsynchronousExpressWorkflow(unittest.TestCase):
 
         message = FileUtilities.get_file_string(Path(self.test_message_dir) / 'soapfault_response_single_error.xml')
 
-        response = httpclient.HTTPResponse
+        response = mock.MagicMock()
         response.code = 500
         response.body = message
         response.headers = {'Content-Type': 'text/xml'}

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_forward_reliable.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_forward_reliable.py
@@ -216,8 +216,7 @@ class TestForwardReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error serialising outbound message', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -236,8 +235,7 @@ class TestForwardReliableWorkflow(unittest.TestCase):
 
         self.assertEqual(400, status)
         self.assertIn('Request to send to Spine is too large', message)
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -253,7 +251,7 @@ class TestForwardReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error obtaining outbound URL', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -431,8 +429,7 @@ class TestForwardReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertTrue('Error when converting retry interval' in message)
         self.assertEqual(
-            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED),
-             mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
             self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('asyncio.sleep')

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_forward_reliable.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_forward_reliable.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -255,6 +256,30 @@ class TestForwardReliableWorkflow(unittest.TestCase):
         self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
+
+    @async_test
+    async def test_non_http_error_handled_when_making_request_to_spine(self):
+        self.setup_mock_work_description()
+        self._setup_routing_mock()
+
+        self.mock_ebxml_request_envelope.return_value.serialize.return_value = (MESSAGE_ID, {}, SERIALIZED_MESSAGE)
+
+        error_future = asyncio.Future()
+        error_future.set_exception(ssl.SSLError())
+        self.mock_transmission_adaptor.make_request.return_value = error_future
+
+        with mock.patch('utilities.config.get_config', return_value='localhost/reliablemessaging/queryrequest'):
+            status, message, _ = await self.workflow.handle_outbound_message(None, MESSAGE_ID, CORRELATION_ID,
+                                                                             INTERACTION_DETAILS,
+                                                                             PAYLOAD, None)
+
+        self.assertEqual(500, status)
+        self.assertEqual("Error making outbound request", message)
+        self.mock_work_description.publish.assert_called_once()
+        self.assertEqual(
+            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED),
+             mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+            self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('asyncio.sleep')
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_reliable.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_reliable.py
@@ -1,4 +1,5 @@
 import asyncio
+import ssl
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -233,6 +234,29 @@ class TestAsynchronousReliableWorkflow(unittest.TestCase):
         self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
+
+    @async_test
+    async def test_non_http_error_handled_when_making_request_to_spine(self):
+        self.setup_mock_work_description()
+        self._setup_routing_mock()
+
+        self.mock_ebxml_request_envelope.return_value.serialize.return_value = (MESSAGE_ID, {}, SERIALIZED_MESSAGE)
+
+        error_future = asyncio.Future()
+        error_future.set_exception(ssl.SSLError())
+        self.mock_transmission_adaptor.make_request.return_value = error_future
+
+        status, message, _ = await self.workflow.handle_outbound_message(None, MESSAGE_ID, CORRELATION_ID,
+                                                                         INTERACTION_DETAILS,
+                                                                         PAYLOAD, None)
+
+        self.assertEqual(500, status)
+        self.assertEqual("Error making outbound request", message)
+        self.mock_work_description.publish.assert_called_once()
+        self.assertEqual(
+            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED),
+             mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+            self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('asyncio.sleep')
     @mock.patch('utilities.integration_adaptors_logger.IntegrationAdaptorsLogger.audit')

--- a/mhs/common/mhs_common/workflow/tests/test_asynchronous_reliable.py
+++ b/mhs/common/mhs_common/workflow/tests/test_asynchronous_reliable.py
@@ -195,8 +195,7 @@ class TestAsynchronousReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error serialising outbound message', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -214,8 +213,7 @@ class TestAsynchronousReliableWorkflow(unittest.TestCase):
 
         self.assertEqual(400, status)
         self.assertIn('Request to send to Spine is too large', message)
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED),
-                          mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -231,7 +229,7 @@ class TestAsynchronousReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertEqual('Error obtaining outbound URL', message)
         self.mock_work_description.publish.assert_called_once()
-        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+        self.assertEqual([mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
                          self.mock_work_description.set_outbound_status.call_args_list)
         self.mock_transmission_adaptor.make_request.assert_not_called()
 
@@ -403,8 +401,7 @@ class TestAsynchronousReliableWorkflow(unittest.TestCase):
         self.assertEqual(500, status)
         self.assertTrue('Error when converting retry interval' in message)
         self.assertEqual(
-            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARED),
-             mock.call(MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)],
+            [mock.call(MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)],
             self.mock_work_description.set_outbound_status.call_args_list)
 
     @mock.patch('asyncio.sleep')

--- a/mhs/common/mhs_common/workflow/tests/test_synchronous.py
+++ b/mhs/common/mhs_common/workflow/tests/test_synchronous.py
@@ -152,7 +152,7 @@ class TestSynchronousWorkflow(unittest.TestCase):
         self.assertEqual(error, 500)
         self.assertEqual(text, 'Error making outbound request')
 
-        log_call = log_mock.warning.call_args
+        log_call = log_mock.error.call_args
         self.assertEqual(log_call[0][0], '0006')
         self.assertEqual(log_call[0][1], 'Error encountered whilst making outbound request. {Exception}')
 

--- a/mhs/common/mhs_common/workflow/tests/test_synchronous.py
+++ b/mhs/common/mhs_common/workflow/tests/test_synchronous.py
@@ -71,7 +71,7 @@ class TestSynchronousWorkflow(unittest.TestCase):
                                                                                        payload="nice message",
                                                                                        work_description_object=None)
 
-        wdo.set_outbound_status.assert_called_with(work_description.MessageStatus.OUTBOUND_MESSAGE_TRANSMISSION_FAILED)
+        wdo.set_outbound_status.assert_called_with(work_description.MessageStatus.OUTBOUND_MESSAGE_PREPARATION_FAILED)
         self.assertEqual(error, 500)
         self.assertEqual(text, 'Error obtaining outbound URL')
         log_mock.error.assert_called_with('009', 'Failed to retrieve details from spine route lookup')


### PR DESCRIPTION
- 3167e41 change a log level from WARNING to ERROR
- 4a11c5e Handle non-HTTP errors (eg SSLError) from outbound transmission in async workflows
- f9c9201 Fix an incorrect way of mocking `HTTPResponse` where the class was being modified
- 342fafc Change outbound statuses set in various places where we were setting outbound status to `OUTBOUND_MESSAGE_TRANSMISSION_FAILED` instead of `OUTBOUND_MESSAGE_PREPARATION_FAILED`