### PR TITLE
[PRMT-610] Lock python version in docker images to 3.7

### DIFF
--- a/pipeline/packer/outbound.json
+++ b/pipeline/packer/outbound.json
@@ -12,7 +12,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3-slim",
+      "image": "python:3.7-slim",
       "container_dir": "/packer-files",
       "commit": true,
       "changes": [

--- a/pipeline/packer/scr-web-service.json
+++ b/pipeline/packer/scr-web-service.json
@@ -12,7 +12,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3-slim",
+      "image": "python:3.7-slim",
       "commit": true,
       "changes": [
         "EXPOSE 80",

--- a/pipeline/packer/spineroutelookup.json
+++ b/pipeline/packer/spineroutelookup.json
@@ -12,7 +12,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3-slim",
+      "image": "python:3.7-slim",
       "commit": true,
       "changes": [
         "EXPOSE 80",


### PR DESCRIPTION
Hi @briandiggle,

This is a fixup to your previous commit. Indeed the versions have to be locked for all images to build.