### PR TITLE
Cleanup docker images properly in the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ pipeline {
                         stage('Component Tests') {
                             steps {
                                 sh label: 'Running component tests', script: '''
-                                    docker build -t componenttest:$BUILD_TAG -f ./component-test.Dockerfile .
+                                    docker build -t local/mhs-componenttest:$BUILD_TAG -f ./component-test.Dockerfile .
                                     docker run --rm --network "${BUILD_TAG_LOWER}_default" \
                                         --env "MHS_ADDRESS=http://outbound" \
                                         --env "AWS_ACCESS_KEY_ID=test" \
@@ -145,7 +145,7 @@ pipeline {
                                         --env "FAKE_SPINE_ADDRESS=http://fakespine" \
                                         --env "MHS_INBOUND_QUEUE_URL=http://rabbitmq:5672" \
                                         --env "SCR_ADDRESS=http://scradaptor" \
-                                        componenttest:$BUILD_TAG
+                                        local/mhs-componenttest:$BUILD_TAG
                                 '''
                             }
                         }


### PR DESCRIPTION
Rename the componenttest image to conform with the docker image deletion pattern