### PR TITLE
NIAD-133: MHS Adaptor - handle Unsolicited Message scenarios

### DIFF
--- a/integration-tests/integration_tests/integration_tests/data/templates/INBOUND_UNEXPECTED_MESSAGE.mustache
+++ b/integration-tests/integration_tests/integration_tests/data/templates/INBOUND_UNEXPECTED_MESSAGE.mustache
@@ -20,7 +20,6 @@ Content-Transfer-Encoding: 8bit
 		<eb:MessageData>
 			<eb:MessageId>{{uuid}}</eb:MessageId>
 			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
-			<eb:RefToMessageId>{{uuid}}</eb:RefToMessageId>
 		</eb:MessageData>
         <eb:DuplicateElimination/>
     </eb:MessageHeader>

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
@@ -35,6 +35,7 @@ class ForwardReliableMessagingPatternTests(TestCase):
     def setUp(self):
         MHS_STATE_TABLE_DYNAMO_WRAPPER.clear_all_records_in_table()
         MHS_SYNC_ASYNC_TABLE_DYNAMO_WRAPPER.clear_all_records_in_table()
+        MHS_INBOUND_QUEUE.drain()
         self.assertions = CommonAssertions('forward-reliable')
 
     def test_should_return_successful_response_from_spine_to_message_queue(self):

--- a/mhs/common/mhs_common/messages/ebxml_envelope.py
+++ b/mhs/common/mhs_common/messages/ebxml_envelope.py
@@ -20,7 +20,7 @@ SERVICE = "service"
 ACTION = "action"
 MESSAGE_ID = 'message_id'
 TIMESTAMP = 'timestamp'
-RECEIVED_MESSAGE_ID = "received_message_id"
+RECEIVED_MESSAGE_ID = "received_message_id"  # RefToMessageId - id of original message sent to outbound
 ERROR_CODE = "error_code"
 SEVERITY = "severity"
 DESCRIPTION = "description"
@@ -41,6 +41,7 @@ class EbxmlEnvelope(envelope.Envelope):
         name: str
         xml_name: str
         xml_parent: str = None
+        required: bool = True
 
     _elements_to_extract_when_parsing = [
         _ElementToExtractWhenParsing(FROM_PARTY_ID, 'PartyId', xml_parent='From'),
@@ -51,7 +52,7 @@ class EbxmlEnvelope(envelope.Envelope):
         _ElementToExtractWhenParsing(ACTION, 'Action'),
         _ElementToExtractWhenParsing(MESSAGE_ID, 'MessageId', xml_parent='MessageData'),
         _ElementToExtractWhenParsing(TIMESTAMP, 'Timestamp', xml_parent='MessageData'),
-        _ElementToExtractWhenParsing(RECEIVED_MESSAGE_ID, 'RefToMessageId', xml_parent='MessageData')
+        _ElementToExtractWhenParsing(RECEIVED_MESSAGE_ID, 'RefToMessageId', xml_parent='MessageData', required=False)
     ]
 
     def __init__(self, template_file: str, message_dictionary: Dict[str, Any]):
@@ -103,11 +104,12 @@ class EbxmlEnvelope(envelope.Envelope):
         extracted_values = {}
 
         for element_to_extract in EbxmlEnvelope._elements_to_extract_when_parsing:
-            EbxmlEnvelope._add_if_present(extracted_values, element_to_extract.name,
-                                          EbxmlEnvelope._extract_ebxml_text_value(xml_tree,
-                                                                                  element_to_extract.xml_name,
-                                                                                  parent=element_to_extract.xml_parent,
-                                                                                  required=True))
+            extracted_value = EbxmlEnvelope._extract_ebxml_text_value(xml_tree,
+                                                                      element_to_extract.xml_name,
+                                                                      parent=element_to_extract.xml_parent,
+                                                                      required=element_to_extract.required)
+            EbxmlEnvelope._add_if_present(extracted_values, element_to_extract.name, extracted_value)
+
 
         return extracted_values
 

--- a/mhs/inbound/inbound/request/handler.py
+++ b/mhs/inbound/inbound/request/handler.py
@@ -1,6 +1,6 @@
 """This module defines the inbound request handler component."""
 
-from typing import Dict
+from typing import Dict, Union
 
 import mhs_common.messages.common_ack_envelope as common_ack_envelope
 import mhs_common.messages.ebxml_ack_envelope as ebxml_ack_envelope
@@ -60,14 +60,19 @@ class InboundHandler(base_handler.BaseHandler):
 
         ref_to_message_id = self._extract_ref_message(request_message)
         correlation_id = self._extract_correlation_id(request_message)
-        self._extract_message_id(request_message)
+        message_id = self._extract_message_id(request_message)
 
         received_message = request_message.message_dictionary[MESSAGE]
 
-        try:
-            work_description = await wd.get_work_description_from_store(self.work_description_store, ref_to_message_id)
-        except wd.EmptyWorkDescriptionError as e:
-            await self._handle_no_work_description_found_for_request(e, ref_to_message_id, correlation_id,
+        if ref_to_message_id:
+            try:
+                work_description = await wd.get_work_description_from_store(self.work_description_store, ref_to_message_id)
+            except wd.EmptyWorkDescriptionError as e:
+                await self._handle_no_work_description_found_for_request(e, message_id, correlation_id,
+                                                                         request_message, received_message)
+                return
+        else:
+            await self._handle_no_work_description_found_for_request(None, message_id, correlation_id,
                                                                      request_message, received_message)
             return
 
@@ -85,7 +90,7 @@ class InboundHandler(base_handler.BaseHandler):
                                         reason=f'Exception in workflow') from e
 
     async def _handle_no_work_description_found_for_request(self, e: wd.EmptyWorkDescriptionError,
-                                                            ref_to_message_id: str, correlation_id: str,
+                                                            message_id: str, correlation_id: str,
                                                             request_message:
                                                             ebxml_request_envelope.EbxmlRequestEnvelope,
                                                             received_message: str):
@@ -98,7 +103,7 @@ class InboundHandler(base_handler.BaseHandler):
         # So let the workflow handle this.
         if isinstance(message_workflow, forward_reliable.AsynchronousForwardReliableWorkflow):
             await self.handle_forward_reliable_unsolicited_request(correlation_id, message_workflow, received_message,
-                                                                   ref_to_message_id, request_message)
+                                                                   message_id, request_message)
 
         # If not, then something has gone wrong
         else:
@@ -112,13 +117,13 @@ class InboundHandler(base_handler.BaseHandler):
     async def handle_forward_reliable_unsolicited_request(self, correlation_id: str,
                                                           forward_reliable_workflow:
                                                           workflow.AsynchronousForwardReliableWorkflow,
-                                                          received_message: str, ref_to_message_id: str,
+                                                          received_message: str, message_id: str,
                                                           request_message: ebxml_request_envelope.EbxmlRequestEnvelope):
         logger.info('Received unsolicited inbound request for the forward-reliable workflow. Passing the '
                     'request to forward-reliable workflow.')
         attachments = request_message.message_dictionary[ebxml_request_envelope.ATTACHMENTS]
         try:
-            await forward_reliable_workflow.handle_unsolicited_inbound_message(ref_to_message_id, correlation_id,
+            await forward_reliable_workflow.handle_unsolicited_inbound_message(message_id, correlation_id,
                                                                                received_message,
                                                                                attachments)
             self._send_ack(request_message)
@@ -168,24 +173,29 @@ class InboundHandler(base_handler.BaseHandler):
 
     def _extract_message_id(self, message):
         """
-        Extracts the message id of the inbound message, this is to be logg
+        Extracts the message id of the inbound message, this is to be included in the standard log format
         :param message:
         :return:
         """
         message_id = message.message_dictionary[MESSAGE_ID]
         mdc.inbound_message_id.set(message_id)
         logger.info('Found inbound message id on request.')
+        return message_id
 
-    def _extract_ref_message(self, message):
+    def _extract_ref_message(self, message) -> Union[str, None]:
         """
         Extracts the reference-to message id and assigns it as the message Id in logging
         :param message:
-        :return: the message id the inbound message is a response to
+        :return: the ref-to message id from the inbound reply or None for unsolicited messages
         """
-        message_id = message.message_dictionary[RECEIVED_MESSAGE_ID]
-        mdc.message_id.set(message_id)
-        logger.info('Found message id on inbound message.')
-        return message_id
+        if RECEIVED_MESSAGE_ID in message.message_dictionary:
+            message_id = message.message_dictionary[RECEIVED_MESSAGE_ID]
+            mdc.message_id.set(message_id)
+            logger.info('Found "reference to" message id on inbound message.')
+            return message_id
+        logger.info('Inbound message did not contain a "reference to" message id')
+        return None
+
 
     def _extract_incoming_ebxml_request_message(self):
         try:

--- a/mhs/inbound/inbound/request/tests/messages/ebxml_no_reference.msg
+++ b/mhs/inbound/inbound/request/tests/messages/ebxml_no_reference.msg
@@ -11,7 +11,7 @@ Content-Transfer-Encoding: 8bit
 			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
 		</eb:From>
 		<eb:To>
-			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">A91424-9199121</eb:PartyId>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">FROM_PARTY_ID</eb:PartyId>
 		</eb:To>
 		<eb:CPAId>S1001A1630</eb:CPAId>
 		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>

--- a/mhs/inbound/inbound/request/tests/messages/ebxml_unknown_ref_to.msg
+++ b/mhs/inbound/inbound/request/tests/messages/ebxml_unknown_ref_to.msg
@@ -1,0 +1,56 @@
+----=_MIME-Boundary
+Content-Id: <ebXMLHeader@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP:Envelope xmlns:xsi="http://www.w3c.org/2001/XML-Schema-Instance" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/" xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:hl7ebxml="urn:hl7-org:transport/ebXML/DSTUv1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
+<SOAP:Header>
+	<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:From>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">YES-0000806</eb:PartyId>
+		</eb:From>
+		<eb:To>
+			<eb:PartyId eb:type="urn:nhs:names:partyType:ocs+serviceInstance">FROM_PARTY_ID</eb:PartyId>
+		</eb:To>
+		<eb:CPAId>S1001A1630</eb:CPAId>
+		<eb:ConversationId>10F5A436-1913-43F0-9F18-95EA0E43E61A</eb:ConversationId>
+		<eb:Service>urn:nhs:names:services:psis</eb:Service>
+		<eb:Action>MCCI_IN010000UK13</eb:Action>
+		<eb:MessageData>
+			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
+			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
+			<eb:RefToMessageId>7A5BCD85-BE30-469B-B584-B26EA71FD377</eb:RefToMessageId>
+		</eb:MessageData>
+        <eb:DuplicateElimination/>
+    </eb:MessageHeader>
+    <eb:AckRequested SOAP:mustUnderstand="1" eb:version="2.0" eb:signed="false" SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH"/>
+    <eb:SyncReply SOAP:mustUnderstand="1" eb:version="2.0" SOAP:actor="http://schemas.xmlsoap.org/soap/actor/next"/>
+</SOAP:Header>
+<SOAP:Body>
+	<eb:Manifest SOAP:mustUnderstand="1" eb:version="2.0">
+		<eb:Reference xlink:href="cid:C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk">
+			<eb:Schema eb:location="http://www.nhsia.nhs.uk/schemas/HL7-Message.xsd" eb:version="1.0"/>
+			<eb:Description xml:lang="en">HL7 payload</eb:Description>
+			<hl7ebxml:Payload style="HL7" encoding="XML" version="3.0"/>
+		</eb:Reference>
+		<eb:Reference xlink:href="cid:8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk">
+            <eb:Description xml:lang="en">Some description</eb:Description>
+        </eb:Reference>
+	</eb:Manifest>
+</SOAP:Body>
+</SOAP:Envelope>
+
+----=_MIME-Boundary
+Content-Id: <C614484E-4B10-499A-9ACD-5D645CFACF61@spine.nhs.uk>
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+<hl7:MCCI_IN010000UK13 xmlns:hl7="urn:hl7-org:v3"/>
+----=_MIME-Boundary
+Content-Id: <8F1D7DE1-02AB-48D7-A797-A947B09F347F@spine.nhs.uk>
+Content-Type: text/plain
+Content-Transfer-Encoding: 8bit
+
+Some payload
+----=_MIME-Boundary--

--- a/mhs/inbound/inbound/request/tests/messages/ebxml_unsolicited.msg
+++ b/mhs/inbound/inbound/request/tests/messages/ebxml_unsolicited.msg
@@ -20,7 +20,6 @@ Content-Transfer-Encoding: 8bit
 		<eb:MessageData>
 			<eb:MessageId>C614484E-4B10-499A-9ACD-5D645CFACF61</eb:MessageId>
 			<eb:Timestamp>2019-05-04T20:55:16Z</eb:Timestamp>
-			<eb:RefToMessageId>B5D38C15-4981-4366-BDE9-8F56EDC4AB72</eb:RefToMessageId>
 		</eb:MessageData>
         <eb:DuplicateElimination/>
     </eb:MessageHeader>


### PR DESCRIPTION
* Made RefToMessageId optional in the header since it is not included in unsolicited messages
* Added additional condition to POST handler to use MessageId instead of RefToMessageId for unsolicited messages
* Updated tests to not include RefToMessageId in unsolicited requests - this is the normal behaviour
* Removed test_no_reference_to_id: longer needed since RefToMessageId is optional for some workflows