### PR TITLE
Feature/niad 837 create s3 bucket for extracts cache

### DIFF
--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -45,7 +45,11 @@ locals {
       value = var.gp2gp_gpc_get_document_endpoint
     },
     {
-      name = "GP2GP_EXTRACT_CACHE_BUCKET"
+      name = "GP2GP_STORAGE_TYPE"
+      value = "S3"
+    },
+   {
+      name = "GP2GP_STORAGE_CONTAINER_NAME"
       value = aws_s3_bucket.gp2gp_extract_cache_bucket.name
     },
     {

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -45,6 +45,10 @@ locals {
       value = var.gp2gp_gpc_get_document_endpoint
     },
     {
+      name = "GP2GP_EXTRACT_CACHE_BUCKET"
+      value = var.gp2gp_extract_cache_bucket
+    },
+    {
       name = "GP2GP_GPC_HOST"
       value = var.gp2gp_gpc_host
     }

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -46,7 +46,7 @@ locals {
     },
     {
       name = "GP2GP_EXTRACT_CACHE_BUCKET"
-      value = var.gp2gp_extract_cache_bucket
+      value = aws_s3_bucket.gp2gp_extract_cache_bucket.name
     },
     {
       name = "GP2GP_GPC_HOST"

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -50,7 +50,7 @@ locals {
     },
    {
       name = "GP2GP_STORAGE_CONTAINER_NAME"
-      value = aws_s3_bucket.gp2gp_extract_cache_bucket.name
+      value = aws_s3_bucket.gp2gp_extract_cache_bucket.id
     },
     {
       name = "GP2GP_GPC_HOST"

--- a/terraform/aws/components/gp2gp/s3.tf
+++ b/terraform/aws/components/gp2gp/s3.tf
@@ -1,11 +1,10 @@
 
 # S3 bucket for storing extracts as cache
 resource "aws_s3_bucket" "gp2gp_extract_cache_bucket" {
-  bucket = "${var.environment_id}-gp2gp-extract-cache-bucket"
-  tags = {
-    Name = "${var.environment_id}-gp2gp-extract-cache-bucket"
-    EnvironmentId = var.environment_id
-  }
+  bucket = "${local.resource_prefix}-extract-cache-bucket"
+  tags = merge(local.default_tags, {
+    Name = "${local.resource_prefix}-extract-cache-bucket"
+  })
   lifecycle_rule {
     id      = "cache_retention_period"
     enabled = true

--- a/terraform/aws/components/gp2gp/s3.tf
+++ b/terraform/aws/components/gp2gp/s3.tf
@@ -1,0 +1,59 @@
+
+# S3 bucket for storing extracts as cache
+resource "aws_s3_bucket" "gp2gp_extract_cache_bucket" {
+  bucket = "${var.environment_id}-gp2gp-extract-cache-bucket"
+  tags = {
+    Name = "${var.environment_id}-gp2gp-extract-cache-bucket"
+    EnvironmentId = var.environment_id
+  }
+  lifecycle_rule {
+    id      = "cache_retention_period"
+    enabled = true
+    expiration {
+      days = var.gp2gp_extract_cache_bucket_retention_period
+    }
+  }
+}
+
+# S3 bucket policy for GP2GP extract cache bucket.
+
+resource "aws_s3_bucket_policy" "gp2gp_extract_cache_bucket_policy" {
+  bucket = aws_s3_bucket.gp2gp_extract_cache_bucket.id
+
+  policy = jsonencode(
+  {
+    Id = "GP2GPExtractCacheBucketPolicy"
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "AllowECSTaskRole"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject"
+        ]
+        Resource = "${aws_s3_bucket.gp2gp_extract_cache_bucket.arn}/*" 
+        Principal = {
+          AWS = data.aws_iam_role.ecs_service_task_role.arn
+        }
+      }
+    ]
+  }
+  )
+}
+
+# Disable any public access to bucket
+resource "aws_s3_bucket_public_access_block" "gp2gp_extract_cache_bucket_public_access_block" {
+  bucket = aws_s3_bucket.gp2gp_extract_cache_bucket.id
+
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+
+  # Need to make sure not to try and disable public access at the same time as adding the
+  # bucket policy, as trying to do both at the same time results in an error.
+  depends_on = [
+    aws_s3_bucket_policy.gp2gp_extract_cache_bucket_policy
+  ]
+}

--- a/terraform/aws/components/gp2gp/variables.tf
+++ b/terraform/aws/components/gp2gp/variables.tf
@@ -153,11 +153,6 @@ variable "gp2gp_service_target_request_count" {
   default = 1200
 }
 
-variable "gp2gp_extract_cache_bucket" {
-  type = string
-  description = "Bucket to store extracts from app to use as cache"
-}
-
 variable "gp2gp_extract_cache_bucket_retention_period" {
   type = number
   description = "Number of days objects will be retained in gp2gp_extract_cache_bucket"

--- a/terraform/aws/components/gp2gp/variables.tf
+++ b/terraform/aws/components/gp2gp/variables.tf
@@ -153,6 +153,17 @@ variable "gp2gp_service_target_request_count" {
   default = 1200
 }
 
+variable "gp2gp_extract_cache_bucket" {
+  type = string
+  description = "Bucket to store extracts from app to use as cache"
+}
+
+variable "gp2gp_extract_cache_bucket_retention_period" {
+  type = number
+  description = "Number of days objects will be retained in gp2gp_extract_cache_bucket"
+  default = 7
+}
+
 variable mhs_inbound_queue_name {
   type = string
   description = "Name of queue used by MHS Inbound "

--- a/terraform/aws/etc/eu-west-2_build1.tfvars
+++ b/terraform/aws/etc/eu-west-2_build1.tfvars
@@ -35,6 +35,7 @@ gp2gp_service_minimal_count = 1
 gp2gp_service_maximal_count = 1
 gp2gp_service_container_port = 8080
 gp2gp_service_launch_type = "FARGATE"
+gp2gp_extract_cache_bucket_retention_period = 7
 
 # Settings for "mhs" component
 mhs_inbound_service_container_port = 443


### PR DESCRIPTION
New local environment variables are added to pass bucket name to app to consume while reading/writing objects to S3 bucket and bucket type = S3

**GP2GP_STORAGE_TYPE=S3
GP2GP_STORAGE_CONTAINER_NAME=bucket.name**


S3 objects retention period control is defined in **etc/eu-west-2_build1.tfvars** file with default value of 7 days using variable **gp2gp_extract_cache_bucket_retention_period**
