### PR TITLE
Feature/niad 930 gp2 gp cloudwatch log fix

### DIFF
--- a/terraform/aws/components/gp2gp/module_ecs_service.tf
+++ b/terraform/aws/components/gp2gp/module_ecs_service.tf
@@ -49,6 +49,8 @@ module "gp2gp_ecs_service" {
 
   additional_container_config = []
 
+  logs_datetime_format = var.gp2gp_logs_datetime_format
+  
   create_testbox=var.create_testbox
   jumpbox_sg_id = data.terraform_remote_state.account.outputs.jumpbox_sg_id
   vpc_id = data.terraform_remote_state.base.outputs.vpc_id

--- a/terraform/aws/components/gp2gp/variables.tf
+++ b/terraform/aws/components/gp2gp/variables.tf
@@ -159,6 +159,12 @@ variable "gp2gp_extract_cache_bucket_retention_period" {
   default = 7
 }
 
+variable "gp2gp_logs_datetime_format" {
+  type = string
+  description = "Format for date and time in AWS cloudwatch logs"
+  default = "%Y-%m-%d %H:%M:%S%L"
+}
+
 variable mhs_inbound_queue_name {
   type = string
   description = "Name of queue used by MHS Inbound "

--- a/terraform/aws/etc/eu-west-2_build1.tfvars
+++ b/terraform/aws/etc/eu-west-2_build1.tfvars
@@ -36,6 +36,7 @@ gp2gp_service_maximal_count = 1
 gp2gp_service_container_port = 8080
 gp2gp_service_launch_type = "FARGATE"
 gp2gp_extract_cache_bucket_retention_period = 7
+gp2gp_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 
 # Settings for "mhs" component
 mhs_inbound_service_container_port = 443


### PR DESCRIPTION
For AWS cloudwatch logs, default datetime stamp is set to "%Y-%m-%d %H:%M:%S%L"