### PR TITLE
NIAD-1035 enable cross zone load balancing

### DIFF
--- a/terraform/aws/modules/module_ecs_service/lb.tf
+++ b/terraform/aws/modules/module_ecs_service/lb.tf
@@ -4,7 +4,9 @@ resource "aws_lb" "service_load_balancer" {
   internal = true
   load_balancer_type = var.load_balancer_type
   security_groups = local.lb_sgs
-  # Needed for LB in AZ A to route to service in AZ B
+
+  # Only used if type is network. Required for Spine which only routes to a
+  # single IP in a single zone but services run in multiple AZ
   enable_cross_zone_load_balancing = true
 
   dynamic "subnet_mapping" {

--- a/terraform/aws/modules/module_ecs_service/lb.tf
+++ b/terraform/aws/modules/module_ecs_service/lb.tf
@@ -4,6 +4,8 @@ resource "aws_lb" "service_load_balancer" {
   internal = true
   load_balancer_type = var.load_balancer_type
   security_groups = local.lb_sgs
+  # Needed for LB in AZ A to route to service in AZ B
+  enable_cross_zone_load_balancing = true
 
   dynamic "subnet_mapping" {
     for_each = local.lb_subnets_to_private_ips


### PR DESCRIPTION
* Spine can only route to a single IP in a specific AZ but services may be deployed in multiple AZ