### PR TITLE
GP2GP mq broker error

### DIFF
--- a/terraform/aws/components/gp2gp/data_mq_broker.tf
+++ b/terraform/aws/components/gp2gp/data_mq_broker.tf
@@ -1,3 +1,3 @@
-data "aws_mq_broker" "nhais_mq_broker" {
+data "aws_mq_broker" "gp2gp_mq_broker" {
   broker_name = var.mq_broker_name
 }

--- a/terraform/aws/components/gp2gp/data_mq_broker.tf
+++ b/terraform/aws/components/gp2gp/data_mq_broker.tf
@@ -1,3 +1,3 @@
-data "aws_mq_broker" "gp2gp_mq_broker" {
+data "aws_mq_broker" "nhais_mq_broker" {
   broker_name = var.mq_broker_name
 }

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -84,10 +84,6 @@ locals {
       value = var.mhs_inbound_queue_name
     },
     {
-      name = "GP2GP_AMQP_BROKERS"
-      value = replace(data.aws_mq_broker.nhais_mq_broker.instances[0].endpoints[1], "amqp+ssl", "amqps")
-    },
-    {
       name = "GP2GP_AMQP_MAX_REDELIVERIES"
       value = var.gp2gp_mock_mhs_amqp_max_redeliveries
     }

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -30,7 +30,7 @@ locals {
     },
     {
       name  = "GP2GP_AMQP_BROKERS"
-      value = replace(data.aws_mq_broker.nhais_mq_broker.instances[0].endpoints[1], "amqp+ssl", "amqps") # https://www.terraform.io/docs/providers/aws/r/mq_broker.html#attributes-reference
+      value = replace(data.aws_mq_broker.gp2gp_mq_broker.instances[0].endpoints[1], "amqp+ssl", "amqps") # https://www.terraform.io/docs/providers/aws/r/mq_broker.html#attributes-reference
     },
     {
       name  = "GP2GP_MHS_INBOUND_QUEUE"

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -30,7 +30,7 @@ locals {
     },
     {
       name  = "GP2GP_AMQP_BROKERS"
-      value = replace(data.aws_mq_broker.gp2gp_mq_broker.instances[0].endpoints[1], "amqp+ssl", "amqps") # https://www.terraform.io/docs/providers/aws/r/mq_broker.html#attributes-reference
+      value = replace(data.aws_mq_broker.nhais_mq_broker.instances[0].endpoints[1], "amqp+ssl", "amqps") # https://www.terraform.io/docs/providers/aws/r/mq_broker.html#attributes-reference
     },
     {
       name  = "GP2GP_MHS_INBOUND_QUEUE"

--- a/terraform/aws/components/gp2gp/terraform.tf
+++ b/terraform/aws/components/gp2gp/terraform.tf
@@ -8,6 +8,6 @@ terraform {
 # Setup AWS provider
 provider "aws" {
   profile = "default"
-  version = "~> 3.37"
+  version = "~> 3.37.0"
   region = var.region
 }

--- a/terraform/aws/components/gp2gp/terraform.tf
+++ b/terraform/aws/components/gp2gp/terraform.tf
@@ -8,6 +8,6 @@ terraform {
 # Setup AWS provider
 provider "aws" {
   profile = "default"
-  version = "~> 3.28"
+  version = "~> 3.37"
   region = var.region
 }

--- a/terraform/aws/components/gp2gp/terraform.tf
+++ b/terraform/aws/components/gp2gp/terraform.tf
@@ -8,5 +8,6 @@ terraform {
 # Setup AWS provider
 provider "aws" {
   profile = "default"
+  version = "~> 3.28"
   region = var.region
 }


### PR DESCRIPTION
GP2GP pipeline was throwing following error

> Error: error setting logs: logs.0.audit: '' expected type 'bool', got unconvertible type 'string'
> 
>   on data_mq_broker.tf line 1, in data "aws_mq_broker" "nhais_mq_broker":
>    1: data "aws_mq_broker" "nhais_mq_broker" {

this was due to a bug in recent hashicorp/aws release version (3.38.0) and was failing gp2gp pipeline. Last working version (3.37.0) has been enforced inside TF configuration for GP2GP adapter.

https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md
