### PR TITLE
NIAD-1612-Enable-AWS-DocumentDb-Encryption

### DIFF
--- a/terraform/aws/components/base/docdb_cluster.tf
+++ b/terraform/aws/components/base/docdb_cluster.tf
@@ -9,6 +9,8 @@ resource "aws_docdb_cluster" "base_db_cluster" {
   db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.base_db_parameters.name
   vpc_security_group_ids          = [ aws_security_group.docdb_sg.id ]
   enabled_cloudwatch_logs_exports = ["audit"]
+  storage_encrypted               = var.docdb_storage_encrypted
+  kms_key_id                      = var.docdb_kms_key_id
 
   tags = merge(local.default_tags,{
     Name = "${local.resource_prefix}-dbcluster"

--- a/terraform/aws/components/base/docdb_parameter_group.tf
+++ b/terraform/aws/components/base/docdb_parameter_group.tf
@@ -1,6 +1,6 @@
 resource "aws_docdb_cluster_parameter_group" "base_db_parameters" {
   name = "${replace(local.resource_prefix,"_","-")}-db-parameters-36"
-  family = "docdb3.6"
+  family = "docdb4.0"
   description = "Parameter group for MongoDB in env: ${var.environment}"
 
   parameter {

--- a/terraform/aws/components/base/variables.tf
+++ b/terraform/aws/components/base/variables.tf
@@ -86,6 +86,16 @@ variable "docdb_master_password" {
   description = "Password for Document DB master user"
 }
 
+variable "docdb_storage_encrypted" {
+  type = string
+  description = "Document DB Encryption-at-rest enablement"
+  default = true
+}
+variable "docdb_kms_key_id" {
+  type = string
+  description = "ARN for AWS KMS Key to encrypt Document DB"
+}
+
 variable "mongo_ssl_enabled" {
   type = bool
   description = "Should the Document DB have a TLS enabled for incomming connections"

--- a/terraform/aws/etc/eu-west-2_build1.tfvars
+++ b/terraform/aws/etc/eu-west-2_build1.tfvars
@@ -4,7 +4,7 @@ environment = "build1"
 base_cidr_block = "10.11.0.0/16"
 cluster_container_insights = "enabled"
 docdb_instance_class = "db.r5.large"
-mongo_ssl_enabled = false
+mongo_ssl_enabled = true
 enable_internet_access = "true"
 create_opentest_instance = true
 

--- a/terraform/aws/etc/eu-west-2_build1.tfvars
+++ b/terraform/aws/etc/eu-west-2_build1.tfvars
@@ -18,7 +18,7 @@ nhais_service_launch_type = "FARGATE"
 nhais_log_level = "DEBUG"
 nhais_mesh_host = "https://msg.opentest.hscic.gov.uk/messageexchange/"
 nhais_mesh_cert_validation = "true"
-nhais_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+nhais_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 
 # Settings for "OneOneOne" component
 # Name changed to "OneOneOne" from "111" because of problems with some Terraform names starting with number
@@ -38,7 +38,7 @@ gp2gp_service_container_port = 8080
 gp2gp_service_launch_type = "FARGATE"
 gp2gp_extract_cache_bucket_retention_period = 7
 gp2gp_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
-gp2gp_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+gp2gp_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 gp2gp_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
 
 # Settings for "gpc-consumer" component
@@ -91,6 +91,6 @@ lab-results_service_launch_type = "FARGATE"
 lab-results_log_level = "DEBUG"
 lab-results_mesh_host = "https://msg.opentest.hscic.gov.uk/messageexchange/"
 lab-results_mesh_cert_validation = "true"
-lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 lab-results_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 lab-results_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"

--- a/terraform/aws/etc/eu-west-2_ptl.tfvars
+++ b/terraform/aws/etc/eu-west-2_ptl.tfvars
@@ -20,7 +20,7 @@ nhais_service_launch_type = "FARGATE"
 nhais_log_level = "DEBUG"
 nhais_mesh_host = "https://msg.int.spine2.ncrs.nhs.uk/messageexchange/"
 nhais_mesh_cert_validation = "true"
-nhais_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+nhais_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 nhais_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
 
 # Settings for "lab-results" component
@@ -33,7 +33,7 @@ lab-results_service_launch_type = "FARGATE"
 lab-results_log_level = "INFO"
 lab-results_mesh_host = "https://msg.int.spine2.ncrs.nhs.uk/messageexchange/"
 lab-results_mesh_cert_validation = "true"
-lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 lab-results_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 lab-results_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
 lab-results_mesh_polling_cycle_minimum_interval_in_seconds = 30
@@ -79,7 +79,7 @@ gp2gp_service_container_port = 8080
 gp2gp_service_launch_type = "FARGATE"
 gp2gp_extract_cache_bucket_retention_period = 7
 gp2gp_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
-gp2gp_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+gp2gp_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 gp2gp_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
 gp2gp_gpc_override_nhs_number = "9690938622"
 gp2gp_gpc_override_to_asid = "200000001329"

--- a/terraform/aws/etc/eu-west-2_ptl.tfvars
+++ b/terraform/aws/etc/eu-west-2_ptl.tfvars
@@ -6,7 +6,7 @@ docdb_instance_class = "db.r5.large"
 ptl_connected = true
 opentest_connected = false
 create_opentest_instance = false
-mongo_ssl_enabled = false
+mongo_ssl_enabled = true
 # enable_internet_access = true
 ptl_allowed_incoming_cidrs = ["10.239.0.0/16"]
 

--- a/terraform/aws/etc/eu-west-2_vp.tfvars
+++ b/terraform/aws/etc/eu-west-2_vp.tfvars
@@ -88,7 +88,7 @@ lab-results_service_launch_type = "FARGATE"
 lab-results_log_level = "INFO"
 lab-results_mesh_host = "https://mesh.vp.nhsredteam.internal.nhs.uk:8829/messageexchange/"
 lab-results_mesh_cert_validation = "false"
-lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
+lab-results_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 lab-results_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 lab-results_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
 lab-results_mesh_polling_cycle_minimum_interval_in_seconds = 30


### PR DESCRIPTION
All DocumetDbs are required to be enabled following attributes

* Encryption-at-rest
* TLS

In 3 environments (Build1/vp/PTL) DocumentDBs has been set up to meet above requirements. Additionally, mongo options string for all adapters have got TLS enabled.