### PR TITLE
NIAD-2812-use-wiremock-gpc-provider

### DIFF
--- a/terraform/aws/components/gp2gp/gpc-consumer-locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/gpc-consumer-locals_env_variables.tf
@@ -12,29 +12,30 @@ locals {
       name  = "GPC_CONSUMER_LOGGING_LEVEL"
       value = var.gpc-consumer_log_level
     },
-    {
-      name  = "GPC_CONSUMER_URL"
-      value = "http://${module.gpc-consumer_ecs_service.loadbalancer_dns_name}:${var.gpc-consumer_service_container_port}"
-    },
-    {
-      name  = "GPC_CONSUMER_OVERRIDE_GPC_PROVIDER_URL"
-      value = var.gp2gp_create_gpcapi_mock ? "http://${module.gpcapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_override_gpc_provider_url
-    },
-    {
-      name  = "GPC_CONSUMER_GPC_GET_URL"
-      value = var.gp2gp_create_sdsapi_mock ? "http://${module.sdsapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_override_gpc_provider_url
-    },
+#    {
+#      name  = "GPC_CONSUMER_URL"
+#      value = "http://${module.gpc-consumer_ecs_service.loadbalancer_dns_name}:${var.gpc-consumer_service_container_port}"
+#    },
+#    {
+#      name  = "GPC_CONSUMER_OVERRIDE_GPC_PROVIDER_URL"
+#      value = var.gp2gp_create_gpcapi_mock ? "http://${module.gpcapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_override_gpc_provider_url
+#    },
+#    {
+#      name  = "GPC_CONSUMER_GPC_GET_URL"
+#      value = var.gp2gp_create_sdsapi_mock ? "http://${module.sdsapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_override_gpc_provider_url
+#    },
     {
       name  = "GPC_CONSUMER_SDS_URL"
-      value = var.gp2gp_create_sdsapi_mock ? "http://${module.sdsapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_sds_url
+#      value = var.gp2gp_create_sdsapi_mock ? "http://${module.sdsapi_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}" : var.gpc-consumer_sds_url
+      value = var.gp2gp_create_wiremock ? "http://${module.gp2gp_wiremock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_wiremock_container_port}/spine-directory/" : var.gpc-consumer_sds_url
     },
     {
-      name  = "GPC_CONSUMER_SSP_FQDN"
-      value = var.gpc-consumer_ssp_fqdn
+      name  = "GPC_CONSUMER_SSP_URL"
+      value = var.gpc-consumer_ssp_url
     },
-    {
-      name  = "GPC_ENABLE_SDS"
-      value = var.gpc_enable_sds
-    }
+#    {
+#      name  = "GPC_ENABLE_SDS"
+#      value = var.gpc_enable_sds
+#    }
   ])
 }

--- a/terraform/aws/components/gp2gp/gpc-consumer-variables.tf
+++ b/terraform/aws/components/gp2gp/gpc-consumer-variables.tf
@@ -117,7 +117,7 @@ variable "gpc-consumer_override_gpc_provider_url" {
   default = "https://GPConnect-Win1.itblab.nic.cfh.nhs.uk"
 }
 
-variable "gpc-consumer_ssp_fqdn" {
+variable "gpc-consumer_ssp_url" {
   type = string
   description = "FQDN for the SDS API"
   default = ""

--- a/terraform/aws/components/gp2gp/locals_env_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_env_variables.tf
@@ -66,7 +66,8 @@ locals {
     },
     {
       name = "GP2GP_GPC_GET_URL"
-      value = var.gp2gp_create_gpcc_mock ? "http://${module.gpcc_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}/GP0001/STU3/1/gpconnect" : "http://${module.gpc-consumer_ecs_service.loadbalancer_dns_name}:${var.gpc-consumer_service_container_port}/B82617/STU3/1/gpconnect"
+      # value = var.gp2gp_create_gpcc_mock ? "http://${module.gpcc_mock_ecs_service[0].loadbalancer_dns_name}:${var.gp2gp_mock_port}/GP0001/STU3/1/gpconnect" : "http://${module.gpc-consumer_ecs_service.loadbalancer_dns_name}:${var.gpc-consumer_service_container_port}/B82617/STU3/1/gpconnect"
+      value = var.gp2gp_create_wiremock ? "http://${module.gpc-consumer_ecs_service[0].loadbalancer_dns_name}:${var.gpc-consumer_service_container_port}/@ODS_CODE@/STU3/1/gpconnect" : var.gp2gp_gpc_get_url
     },
     {
       name = "GP2GP_GPC_OVERRIDE_NHS_NUMBER"

--- a/terraform/aws/etc/eu-west-2_ptl.tfvars
+++ b/terraform/aws/etc/eu-west-2_ptl.tfvars
@@ -84,9 +84,10 @@ gp2gp_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 gp2gp_log_level = "INFO"
 gp2gp_mongo_options = "replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false&tls=true"
 gp2gp_ssl_trust_store_url = "s3://nhsd-aws-truststore/rds-truststore.jks"
-gp2gp_gpc_override_nhs_number = "9690938622"
-gp2gp_gpc_override_to_asid = "200000001329"
-gp2gp_gpc_override_from_asid = "200000001467"
+#gp2gp_gpc_override_nhs_number = "9690938622"
+#gp2gp_gpc_override_to_asid = "200000001329"
+#gp2gp_gpc_override_from_asid = "200000001467"
+gp2gp_create_wiremock = true
 
 # Settings for "gpc-consumer" component
 gpc-consumer_service_minimal_count = 1
@@ -98,10 +99,10 @@ gpc-consumer_service_launch_type = "FARGATE"
 gpc-consumer_root_log_level = "WARN"
 gpc-consumer_log_level = "INFO"
 gpc-consumer_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
-gpc-consumer_override_gpc_provider_url = "https://GPConnect-Win1.itblab.nic.cfh.nhs.uk"
-gpc-consumer_sds_url = "https://int.api.service.nhs.uk/spine-directory/FHIR/R4"
-gpc_enable_sds = "true"
-gpc-consumer_ssp_fqdn = "https://proxy.int.spine2.ncrs.nhs.uk/"
+#gpc-consumer_override_gpc_provider_url = "https://GPConnect-Win1.itblab.nic.cfh.nhs.uk"
+#gpc-consumer_sds_url = "https://int.api.service.nhs.uk/spine-directory/FHIR/R4" # using wiremock instead
+#gpc_enable_sds = "true" # maybe not needed anymore
+#gpc-consumer_ssp_fqdn = "https://proxy.int.spine2.ncrs.nhs.uk/"
 
 ###### FOR GPC-CONSUMER TO BE DEPLOYED IN PTL ENVIRONMENT
 gpc-consumer_include_certs = true


### PR DESCRIPTION
Update PTL terraform variables to use wiremock GPC provider.