### PR TITLE
Increase default size of jump box

### DIFF
--- a/terraform/aws/components/account/variables.tf
+++ b/terraform/aws/components/account/variables.tf
@@ -49,12 +49,12 @@ variable "jumpbox_allowed_ssh" {
 
 variable "jumpbox_size" {
   type = "string"
-  default = "t2.micro"
+  default = "t3a.medium"
 }
 
 variable "jumpbox_volume_size" {
   type = number
-  default = 16
+  default = 32
 }
 
 variable "mq_vpc_id" {


### PR DESCRIPTION
## What

Increase the instance and storage size of the AWS Jump Box.  

## Why

To make it possible to run the PS Adaptors scripts for populating the SNOMED tables in the Postgres database

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code