### PR TITLE
Switch MHS Adaptor in PTL to use FHIR API

### DIFF
--- a/terraform/aws/components/mhs/data_secrets.tf
+++ b/terraform/aws/components/mhs/data_secrets.tf
@@ -39,3 +39,7 @@ data "aws_secretsmanager_secret" "mhs_ca_certs" {
 data "aws_secretsmanager_secret" "spine_routelookup_ca_certs" {
   name = var.secret_name_mhs_spine_route_lookup_ca_certs
 }
+
+data "aws_secretsmanager_secret" "sds_apikey" {
+  name = var.secret_name_sds_apikey
+}

--- a/terraform/aws/components/mhs/locals_env_variables.tf
+++ b/terraform/aws/components/mhs/locals_env_variables.tf
@@ -21,6 +21,14 @@ locals {
       name = "MHS_DB_ENDPOINT_URL"
       value = join("&",[data.terraform_remote_state.base.outputs.docdb_cluster_connection_string,"ssl=${data.terraform_remote_state.base.outputs.docdb_tls_enabled}"])
     },
+    {
+      name  = "MHS_OUTBOUND_ROUTING_LOOKUP_METHOD"
+      value = "SDS_API"
+    },
+    {
+      name  = "MHS_SDS_API_URL"
+      value = var.gpc-consumer_sds_url
+    }
   ])
 
   outbound_variables = concat(local.environment_variables, [

--- a/terraform/aws/components/mhs/locals_secret_variables.tf
+++ b/terraform/aws/components/mhs/locals_secret_variables.tf
@@ -24,6 +24,10 @@ locals {
       name = "MHS_SECRET_CA_CERTS"
       valueFrom = data.aws_secretsmanager_secret.mhs_ca_certs.arn
     },
+    {
+      name = "MHS_SDS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.sds_apikey.arn
+    }
     # {
     #   name = "MHS_MONGO_USERNAME"
     #   valueFrom = data.aws_secretsmanager_secret.docdb_master_username.arn

--- a/terraform/aws/components/mhs/variables.tf
+++ b/terraform/aws/components/mhs/variables.tf
@@ -308,3 +308,12 @@ variable secret_name_mhs_spine_route_lookup_ca_certs {
   type = string
   default = "build-outbound-route-connection-cacerts"
 }
+
+variable "gpc-consumer_sds_url" {
+  type = string
+  description = "URL to the SDS API"
+}
+
+variable secret_name_sds_apikey {
+  type = string
+}

--- a/terraform/aws/etc/eu-west-2_ptl.tfvars
+++ b/terraform/aws/etc/eu-west-2_ptl.tfvars
@@ -99,6 +99,7 @@ gpc-consumer_logs_datetime_format = "%Y-%m-%d %H:%M:%S%L"
 
 ###### FOR GPC-CONSUMER TO BE DEPLOYED IN PTL ENVIRONMENT
 gpc-consumer_include_certs = false
+gpc-consumer_sds_url = "https://int.api.service.nhs.uk/spine-directory/FHIR/R4"
 secret_name_spine_client_cert = "gpc_consumer_spine_client_cert"
 secret_name_spine_client_key = "gpc_consumer_spine_client_key"
 secret_name_spine_root_ca_cert = "gpc_consumer_spine_root_ca_cert"


### PR DESCRIPTION
The current SDS certificate for the MHS Route service has expired.

Switch to the FHIR API as it will be easier than renewing the SDS certificate.