### PR TITLE
Pass in PDS secret values to the GP2GP Wiremock

### DIFF
--- a/terraform/aws/components/gp2gp/data_secrets.tf
+++ b/terraform/aws/components/gp2gp/data_secrets.tf
@@ -17,3 +17,15 @@ data "aws_secretsmanager_secret" "docdb_master_password" {
 data "aws_secretsmanager_secret" "gp2gp_ssl_trust_store_password" {
   name = "nhais_${var.environment}_ssl_trust_store_password"
 }
+
+data "aws_secretsmanager_secret" "pds_key_id" {
+  name = "pds-key-id"
+}
+
+data "aws_secretsmanager_secret" "pds_api_key" {
+  name = "pds-api-key"
+}
+
+data "aws_secretsmanager_secret" "pds_private_key" {
+  name = "pds-private-key"
+}

--- a/terraform/aws/components/gp2gp/locals_secret_variables.tf
+++ b/terraform/aws/components/gp2gp/locals_secret_variables.tf
@@ -21,4 +21,19 @@ locals {
       valueFrom = data.aws_secretsmanager_secret.gp2gp_ssl_trust_store_password.arn
     }
   ]
+
+  wiremock_secret_variables = [
+    {
+      name      = "PDS_KEY_ID"
+      valueFrom = data.aws_secretsmanager_secret.pds_key_id.arn
+    },
+    {
+      name      = "PDS_API_KEY"
+      valueFrom = data.aws_secretsmanager_secret.pds_api_key.arn
+    },
+    {
+      name      = "PDS_PRIVATE_KEY"
+      valueFrom = data.aws_secretsmanager_secret.pds_private_key.arn
+    }
+  ]
 }

--- a/terraform/aws/components/gp2gp/module_wiremock_ecs_service.tf
+++ b/terraform/aws/components/gp2gp/module_wiremock_ecs_service.tf
@@ -33,7 +33,7 @@ module "gp2gp_wiremock_ecs_service" {
   dlt_vpc_id                 = var.dlt_vpc_id
 
   #environment_variables = local.environment_variables
-  #secret_variables      = local.secret_variables
+  secret_variables      = local.wiremock_secret_variables
 
   task_execution_role_arn = aws_iam_role.ecs_service_task_execution_role.arn
   task_role_arn           = data.aws_iam_role.ecs_service_task_role.arn


### PR DESCRIPTION
This way the mock can be configured to return "real" patient details using PDS.